### PR TITLE
Shorter example in main module, long one in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ defmodule MyApp.Factories do
   def factory(:comment, opts) do
     %Comment{
       body: "This is great!",
+      author_email: sequence(:email, &"email-#{&1}@example.com"),
       article_id: assoc(opts, :article).id
     }
   end

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -2,54 +2,7 @@ defmodule ExMachina do
   @moduledoc """
   Defines functions for generating data
 
-  ## Examples
-
-      # test/factories.ex
-      defmodule MyApp.Factories do
-        use ExMachina
-
-        def factory(:config) do
-          # Factories can be plain maps
-          %{url: "http://example.com"}
-        end
-
-        def factory(:article) do
-          %Article{
-            title: "My Awesome Article"
-          }
-        end
-
-        def factory(:comment, opts) do
-          %Comment{
-            body: "This is great!",
-            article_id: assoc(opts, :article).id
-          }
-        end
-
-        def create_record(map) do
-          # This example uses Ecto to save records
-          MyApp.Repo.insert!(map)
-        end
-      end
-
-  Then use it in your tests. This is an example with Phoenix.
-
-      defmodule MyApp.MyModuleTest do
-        use MyApp.ConnCase
-        # You can add this to your MyApp.ConnCase when using Phoenix
-        import MyApp.Factories
-
-        test "shows comments for an article" do
-          conn = conn()
-          article = create(:article)
-          comment = create(:comment, article: article)
-
-          conn = get conn, article_path(conn, :show, article.id)
-
-          assert html_response(conn, 200) =~ article.title
-          assert html_response(conn, 200) =~ comment.body
-        end
-      end
+  In depth examples are in the [README](README.html)
   """
 
   defmodule UndefinedFactory do

--- a/mix.exs
+++ b/mix.exs
@@ -2,11 +2,12 @@ defmodule ExMachina.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/thoughtbot/ex_machina"
+  @version "0.0.1"
 
   def project do
     [
       app: :ex_machina,
-      version: "0.0.1",
+      version: @version,
       elixir: "~> 1.0",
       description: "Easily create test data for Elixir applications",
       source_url: @project_url,
@@ -14,7 +15,7 @@ defmodule ExMachina.Mixfile do
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       package: package,
-      docs: [extras: ["README.md"]],
+      docs: [main: "README", extras: ["README.md"]],
       deps: deps
     ]
   end


### PR DESCRIPTION
Make README the in-depth, authoritative source for examples.