### PR TITLE
Simplify factory definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ defmodule MyApp.Factories do
   # It will automatically be used when calling `create`
   use ExMachina, repo: MyApp.Repo
 
-  def factory(:config) do
+  def config(_attrs) do
     # Factories can be plain maps
     %{url: "http://example.com"}
   end
 
-  def factory(:article) do
+  def factory(_attrs) do
     %Article{
       title: "My Awesome Article"
     }
   end
 
-  def factory(:comment, attrs) do
+  def comment(attrs) do
     %Comment{
       body: "This is great!",
       author_email: sequence(:email, &"email-#{&1}@example.com"),
@@ -86,7 +86,7 @@ defmodule MyApp.JsonFactories do
   # Note `repo` was not passed as an option
   use ExMachina
 
-  def factory(:user), do: %User{name: "John"}
+  def user(_attrs), do: %User{name: "John"}
 
   def save_function(record) do
     # Poison is a library for working with JSON
@@ -106,7 +106,7 @@ or `create_json` to return encoded JSON objects.
 defmodule MyApp.Factories do
   use ExMachina, repo: MyApp.Repo
 
-  def factory(:user), do: %User{name: "John"}
+  def user(_attrs), do: %User{name: "John"}
 
   # builds the object and then encodes it as JSON
   def build_json(factory_name, attrs) do

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -19,13 +19,13 @@ defmodule ExMachinaTest do
   defmodule MyApp.ExMachina do
     use ExMachina, repo: TestRepo
 
-    def factory(:book) do
+    def book(_attrs) do
       %MyApp.Book{
         title: "Foo"
       }
     end
 
-    def factory(:user) do
+    def user(_attrs) do
       %{
         id: 3,
         name: "John Doe",
@@ -33,20 +33,20 @@ defmodule ExMachinaTest do
       }
     end
 
-    def factory(:account) do
+    def account(_attrs) do
       %{
         id: 100,
         plan_type: "enterprise"
       }
     end
 
-    def factory(:email) do
+    def email(_attrs) do
       %{
         email: sequence(:email, &"me-#{&1}@foo.com")
       }
     end
 
-    def factory(:article, attrs) do
+    def article(attrs) do
       %{
         id: 1,
         title: "My Awesome Article",
@@ -54,7 +54,7 @@ defmodule ExMachinaTest do
       }
     end
 
-    def factory(:comment, attrs) do
+    def comment(attrs) do
       %{
         body: "This is great!",
         article_id: assoc(attrs, :article).id
@@ -65,7 +65,7 @@ defmodule ExMachinaTest do
   defmodule MyApp.NonEctoFactories do
     use ExMachina
 
-    def factory(:foo), do: %{foo: :bar}
+    def foo(_attrs), do: %{foo: :bar}
 
     def save_function(record) do
       send self, {:custom_save, record}
@@ -76,7 +76,7 @@ defmodule ExMachinaTest do
   defmodule MyApp.NoSaveFunction do
     use ExMachina
 
-    def factory(:foo), do: %{foo: :bar}
+    def foo(_attrs), do: %{foo: :bar}
   end
 
   test "sequence/2 sequences a value" do
@@ -120,12 +120,8 @@ defmodule ExMachinaTest do
     assert comment.article == my_article
   end
 
-  test "factories can be defined without the attrs param" do
-    assert MyApp.ExMachina.build(:user) == MyApp.ExMachina.factory(:user)
-  end
-
   test "raises a helpful error if the factory is not defined" do
-    assert_raise ExMachina.UndefinedFactory, "No factory defined for :foo", fn ->
+    assert_raise ExMachina.UndefinedFactory, fn ->
       MyApp.ExMachina.build(:foo)
     end
   end


### PR DESCRIPTION
@jsteiner @BlakeWilliams I think this is nicer to read and to write. It also makes it so we don't get warning about grouping similar functions together.

The only downside I see is that you have to define `_attrs`, but I still think that's cleaner than what we had before

What do you think?