### PR TITLE
Extract all Ecto functionality to separate module

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ defp app_list,  do: [:logger]
 defmodule MyApp.Factories do
   # MyApp.Repo is an Ecto Repo.
   # It will automatically be used when calling `create`
-  use ExMachina, repo: MyApp.Repo
+  use ExMachina.Ecto, repo: MyApp.Repo
 
   def factory(:config) do
     # Factories can be plain maps
@@ -83,7 +83,6 @@ defining `save_function/1` in your module.
 
 ```elixir
 defmodule MyApp.JsonFactories do
-  # Note `repo` was not passed as an option
   use ExMachina
 
   def factory(:user), do: %User{name: "John"}
@@ -104,7 +103,7 @@ or `create_json` to return encoded JSON objects.
 
 ```elixir
 defmodule MyApp.Factories do
-  use ExMachina, repo: MyApp.Repo
+  use ExMachina.Ecto, repo: MyApp.Repo
 
   def factory(:user), do: %User{name: "John"}
 

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -20,16 +20,15 @@ defmodule ExMachina do
 
   defmodule UndefinedSave do
     @moduledoc """
-    Error raised when trying to call create and no repo or save_function is
-    defined.
+    Error raised when trying to call create and save_record/1 is
+    not defined.
     """
 
     defexception [:message]
 
     def exception do
       %UndefinedSave{
-        message: "Define save_function/1 or include the repo option. See docs
-        for ExMachina.save_record."
+        message: "Define save_record/1. See docs for ExMachina.save_record/1."
       }
     end
   end
@@ -38,20 +37,11 @@ defmodule ExMachina do
 
   def start(_type, _args), do: ExMachina.Sequence.start_link
 
-  defmacro __using__(opts) do
+  defmacro __using__(_opts) do
     quote do
       @before_compile unquote(__MODULE__)
-      @repo Dict.get(unquote(opts), :repo)
 
       import ExMachina, only: [sequence: 2]
-
-      defp assoc(attrs, factory_name, opts \\ []) do
-        ExMachina.assoc(__MODULE__, attrs, factory_name, opts)
-      end
-
-      def fields_for(factory_name, attrs \\ %{}) do
-        ExMachina.fields_for(__MODULE__, factory_name, attrs)
-      end
 
       def build(factory_name, attrs \\ %{}) do
         ExMachina.build(__MODULE__, factory_name, attrs)
@@ -67,10 +57,6 @@ defmodule ExMachina do
 
       def create_list(number_of_factories, factory_name, attrs \\ %{}) do
         ExMachina.create_list(__MODULE__, number_of_factories, factory_name, attrs)
-      end
-
-      def save_record(record) do
-        ExMachina.save_record(__MODULE__, @repo, record)
       end
     end
   end
@@ -88,69 +74,6 @@ defmodule ExMachina do
       end
   """
   def sequence(name, formatter), do: ExMachina.Sequence.next(name, formatter)
-
-  @doc """
-  Gets a factory from the passed in attrs, or creates if none is present
-
-  ## Examples
-
-      attrs = %{user: %{name: "Someone"}}
-      # Returns attrs.user
-      assoc(attrs, :user)
-
-      attrs = %{}
-      # Creates and returns new instance based on :user factory
-      assoc(attrs, :user)
-
-      attrs = %{}
-      # Creates and returns new instance based on :user factory
-      assoc(attrs, :author, factory: :user)
-  """
-  def assoc(module, attrs, factory_name, opts \\ []) do
-    case Map.get(attrs, factory_name) do
-      nil -> create_assoc(module, factory_name, opts)
-      record -> record
-    end
-  end
-
-  defp create_assoc(module, _factory_name, factory: factory_name) do
-    ExMachina.create(module, factory_name)
-  end
-  defp create_assoc(module, factory_name, _opts) do
-    ExMachina.create(module, factory_name)
-  end
-
-  @doc """
-  Builds a factory with the passed in factory_name and returns its fields
-
-  This is only for use with Ecto models.
-
-  Will return a map with the fields and virtual fields, but without the Ecto
-  metadata and associations.
-
-  ## Example
-
-      def factory(:user) do
-        %MyApp.User{name: "John Doe", admin: false}
-      end
-
-      # Returns %{name: "John Doe", admin: true}
-      fields_for(:user, admin: true)
-  """
-  def fields_for(module, factory_name, attrs \\ %{}) do
-    module.build(factory_name, attrs)
-    |> drop_ecto_fields
-  end
-
-  defp drop_ecto_fields(record = %{__struct__: struct, __meta__: %{__struct__: Ecto.Schema.Metadata}}) do
-    record
-    |> Map.from_struct
-    |> Map.delete(:__meta__)
-    |> Map.drop(struct.__schema__(:associations))
-  end
-  defp drop_ecto_fields(record) do
-    raise ArgumentError, "#{inspect record} is not an Ecto model. Use `build` instead."
-  end
 
   @doc """
   Builds a factory with the passed in factory_name
@@ -172,10 +95,11 @@ defmodule ExMachina do
   @doc """
   Builds and saves a factory with the passed in factory_name
 
-  If you pass in repo when using ExMachina it will use the Ecto Repo to save the
-  record automatically. If you do not pass the repo, you need to define a
-  `save_record/1` function in your module. See `save_record` docs for more
-  information.
+  If using ExMachina.Ecto it will use the Ecto Repo passed in to save the
+  record automatically.
+
+  If you are not using ExMachina.Ecto, you need to define a `save_record/1`
+  function in your module. See `save_record` docs for more information.
 
   ## Example
 
@@ -188,50 +112,6 @@ defmodule ExMachina do
   """
   def create(module, factory_name, attrs \\ %{}) do
     ExMachina.build(module, factory_name, attrs) |> module.save_record
-  end
-
-
-  @doc """
-  Saves a record when `create` is called. Uses Ecto if the `repo` option is set
-
-  If you include the `repo` option (`use ExMachina, repo: MyApp.Repo`) this
-  function will call `insert!` on the passed in repo. 
-
-  If you do not pass in the `repo` option, you must define a custom
-  save_function/1 for saving the record.
-
-  ## Examples
-
-      defmodule MyApp.Factories do
-        use ExMachina, repo: MyApp.Repo
-
-        def factory(:user), do: %User{name: "John"}
-      end
-
-      # Will build and save the record to the MyApp.Repo
-      MyApp.Factories.create(:user)
-
-      defmodule MyApp.JsonFactories do
-        # Note `repo` was not passed as an option
-        use ExMachina
-
-        def factory(:user), do: %User{name: "John"}
-
-        def save_function(record) do
-          # Poison is a library for working with JSON
-          Poison.encode!(record)
-        end
-      end
-
-      # Will build and then return a JSON encoded version of the map
-      MyApp.JsonFactories.create(:user)
-  """
-  def save_record(module, repo, record) do
-    if repo do
-      repo.insert!(record)
-    else
-      module.save_function(record)
-    end
   end
 
   @doc """
@@ -279,10 +159,41 @@ defmodule ExMachina do
       end
 
       @doc """
-      Raises a helpful error if `create` is called and no save_function is
-      defined.
+      Saves a record when `create` is called. Uses Ecto if using ExMachina.Ecto
+
+      If using ExMachina.Ecto (`use ExMachina.Ecto, repo: MyApp.Repo`) this
+      function will call `insert!` on the passed in repo.
+
+      If you are not using ExMachina.Ecto, you must define a custom
+      save_record/1 for saving the record.
+
+      ## Examples
+
+          defmodule MyApp.Factories do
+            use ExMachina.Ecto, repo: MyApp.Repo
+
+            def factory(:user), do: %User{name: "John"}
+          end
+
+          # Will build and save the record to the MyApp.Repo
+          MyApp.Factories.create(:user)
+
+          defmodule MyApp.JsonFactories do
+            # Note, we are not using ExMachina.Ecto
+            use ExMachina
+
+            def factory(:user), do: %User{name: "John"}
+
+            def save_function(record) do
+              # Poison is a library for working with JSON
+              Poison.encode!(record)
+            end
+          end
+
+          # Will build and then return a JSON encoded version of the map
+          MyApp.JsonFactories.create(:user)
       """
-      def save_function(record) do
+      def save_record(record) do
         raise UndefinedSave
       end
     end

--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -1,0 +1,93 @@
+defmodule ExMachina.Ecto do
+  defmacro __using__(opts) do
+    quote do
+      use ExMachina
+
+      @repo Dict.fetch!(unquote(opts), :repo)
+
+      def fields_for(factory_name, attrs \\ %{}) do
+        ExMachina.Ecto.fields_for(__MODULE__, factory_name, attrs)
+      end
+
+      defp assoc(attrs, factory_name, opts \\ []) do
+        ExMachina.Ecto.assoc(__MODULE__, attrs, factory_name, opts)
+      end
+
+      def save_record(record) do
+        ExMachina.Ecto.save_record(__MODULE__, @repo, record)
+      end
+    end
+  end
+
+  @doc """
+  Builds a factory with the passed in factory_name and returns its fields
+
+  This is only for use with Ecto models.
+
+  Will return a map with the fields and virtual fields, but without the Ecto
+  metadata and associations.
+
+  ## Example
+
+      def factory(:user) do
+        %MyApp.User{name: "John Doe", admin: false}
+      end
+
+      # Returns %{name: "John Doe", admin: true}
+      fields_for(:user, admin: true)
+  """
+  def fields_for(module, factory_name, attrs \\ %{}) do
+    module.build(factory_name, attrs)
+    |> drop_ecto_fields
+  end
+
+  defp drop_ecto_fields(record = %{__struct__: struct, __meta__: %{__struct__: Ecto.Schema.Metadata}}) do
+    record
+    |> Map.from_struct
+    |> Map.delete(:__meta__)
+    |> Map.drop(struct.__schema__(:associations))
+  end
+  defp drop_ecto_fields(record) do
+    raise ArgumentError, "#{inspect record} is not an Ecto model. Use `build` instead."
+  end
+
+  @doc """
+  Gets a factory from the passed in attrs, or creates if none is present
+
+  ## Examples
+
+      attrs = %{user: %{name: "Someone"}}
+      # Returns attrs.user
+      assoc(attrs, :user)
+
+      attrs = %{}
+      # Creates and returns new instance based on :user factory
+      assoc(attrs, :user)
+
+      attrs = %{}
+      # Creates and returns new instance based on :user factory
+      assoc(attrs, :author, factory: :user)
+  """
+  def assoc(module, attrs, factory_name, opts \\ []) do
+    case Map.get(attrs, factory_name) do
+      nil -> create_assoc(module, factory_name, opts)
+      record -> record
+    end
+  end
+
+  defp create_assoc(module, _factory_name, factory: factory_name) do
+    ExMachina.create(module, factory_name)
+  end
+  defp create_assoc(module, factory_name, _opts) do
+    ExMachina.create(module, factory_name)
+  end
+
+  @doc """
+  Saves a record using `Repo.insert!` when `create` is called.
+  """
+  def save_record(module, repo, record) do
+    if repo do
+      repo.insert!(record)
+    end
+  end
+end

--- a/test/ex_machina/ecto_test.ex
+++ b/test/ex_machina/ecto_test.ex
@@ -1,0 +1,115 @@
+defmodule ExMachina.EctoTest do
+  use ExUnit.Case, async: true
+
+  defmodule TestRepo do
+    def insert!(record) do
+      send self, {:created, record}
+      record
+    end
+  end
+
+  defmodule MyApp.Book do
+    defstruct title: nil, publisher: nil, __meta__: %{__struct__: Ecto.Schema.Metadata}, publisher_id: 1
+
+    def __schema__(:associations) do
+      [:publisher]
+    end
+  end
+
+  defmodule MyApp.EctoFactories do
+    use ExMachina.Ecto, repo: TestRepo
+
+    def factory(:book) do
+      %MyApp.Book{
+        title: "Foo"
+      }
+    end
+
+    def factory(:user) do
+      %{
+        id: 3,
+        name: "John Doe",
+        admin: false
+      }
+    end
+
+    def factory(:article, attrs) do
+      %{
+        id: 1,
+        title: "My Awesome Article",
+        author_id: assoc(attrs, :author, factory: :user).id
+      }
+    end
+
+    def factory(:comment, attrs) do
+      %{
+        body: "This is great!",
+        article_id: assoc(attrs, :article).id
+      }
+    end
+  end
+
+  test "raises error if no repo is provided" do
+    assert_raise KeyError, "key :repo not found in: []", fn ->
+      defmodule MyApp.EctoWithNoRepo do
+        use ExMachina.Ecto
+      end
+    end
+  end
+
+  test "fields_for/2 removes Ecto specific fields" do
+    assert MyApp.EctoFactories.fields_for(:book) == %{
+      title: "Foo",
+      publisher_id: 1,
+    }
+  end
+
+  test "fields_for/2 raises when passed a map" do
+    assert_raise ArgumentError, fn ->
+      MyApp.EctoFactories.fields_for(:user)
+    end
+  end
+
+  test "save_record/1 passes the data to @repo.insert!" do
+    user = MyApp.EctoFactories.save_record(:user, admin: true)
+
+    assert user == %{id: 3, name: "John Doe", admin: true}
+    assert_received {:created, %{name: "John Doe", admin: true}}
+  end
+
+  test "assoc/3 returns the passed in key if it exists" do
+    existing_account = %{id: 1, plan_type: "free"}
+    attrs = %{account: existing_account}
+
+    assert MyApp.EctoFactories.assoc(MyApp.EctoFactories, attrs, :account) == existing_account
+    refute_received {:custom_save, _}
+  end
+
+  test "assoc/3 creates and returns a factory if one was not in attrs" do
+    attrs = %{}
+
+    user = MyApp.EctoFactories.assoc(MyApp.EctoFactories, attrs, :user)
+
+    created_user = %{id: 3, name: "John Doe", admin: true}
+    assert user == created_user
+    assert_received {:custom_save, ^created_user}
+  end
+
+  test "assoc/3 can specify a factory for the association" do
+    attrs = %{}
+
+    account = MyApp.EctoFactories.assoc(MyApp.EctoFactories, attrs, :account, factory: :user)
+
+    newly_created_account = %{id: 3, admin: false, name: "John Doe"}
+    assert account == newly_created_account
+    assert_received {:custom_save, ^newly_created_account}
+  end
+
+  test "can use assoc/3 in a factory to override associations" do
+    my_article = MyApp.EctoFactories.create(:article, title: "So Deep")
+
+    comment = MyApp.EctoFactories.create(:comment, article: my_article)
+
+    assert comment.article == my_article
+  end
+end

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -1,29 +1,8 @@
 defmodule ExMachinaTest do
   use ExUnit.Case, async: true
 
-  defmodule TestRepo do
-    def insert!(record) do
-      send self, {:created, record}
-      record
-    end
-  end
-
-  defmodule MyApp.Book do
-    defstruct title: nil, publisher: nil, __meta__: %{__struct__: Ecto.Schema.Metadata}, publisher_id: 1
-
-    def __schema__(:associations) do
-      [:publisher]
-    end
-  end
-
-  defmodule MyApp.ExMachina do
-    use ExMachina, repo: TestRepo
-
-    def factory(:book) do
-      %MyApp.Book{
-        title: "Foo"
-      }
-    end
+  defmodule MyApp.Factories do
+    use ExMachina
 
     def factory(:user) do
       %{
@@ -33,41 +12,13 @@ defmodule ExMachinaTest do
       }
     end
 
-    def factory(:account) do
-      %{
-        id: 100,
-        plan_type: "enterprise"
-      }
-    end
-
     def factory(:email) do
       %{
         email: sequence(:email, &"me-#{&1}@foo.com")
       }
     end
 
-    def factory(:article, attrs) do
-      %{
-        id: 1,
-        title: "My Awesome Article",
-        author_id: assoc(attrs, :author, factory: :user).id
-      }
-    end
-
-    def factory(:comment, attrs) do
-      %{
-        body: "This is great!",
-        article_id: assoc(attrs, :article).id
-      }
-    end
-  end
-
-  defmodule MyApp.NonEctoFactories do
-    use ExMachina
-
-    def factory(:foo), do: %{foo: :bar}
-
-    def save_function(record) do
+    def save_record(record) do
       send self, {:custom_save, record}
       record
     end
@@ -80,71 +31,22 @@ defmodule ExMachinaTest do
   end
 
   test "sequence/2 sequences a value" do
-    assert "me-0@foo.com" == MyApp.ExMachina.build(:email).email
-    assert "me-1@foo.com" == MyApp.ExMachina.build(:email).email
-  end
-
-  test "assoc/3 returns the passed in key if it exists" do
-    existing_account = %{id: 1, plan_type: "free"}
-    attrs = %{account: existing_account}
-
-    assert ExMachina.assoc(MyApp.ExMachina, attrs, :account) == existing_account
-    refute_received {:created, _}
-  end
-
-  test "assoc/3 creates and returns a factory if one was not in attrs" do
-    attrs = %{}
-
-    account = ExMachina.assoc(MyApp.ExMachina, attrs, :account)
-
-    newly_created_account = %{id: 100, plan_type: "enterprise"}
-    assert account == newly_created_account
-    assert_received {:created, ^newly_created_account}
-  end
-
-  test "assoc/3 can specify a factory for the association" do
-    attrs = %{}
-
-    account = ExMachina.assoc(MyApp.ExMachina, attrs, :account, factory: :user)
-
-    newly_created_account = %{id: 3, admin: false, name: "John Doe"}
-    assert account == newly_created_account
-    assert_received {:created, ^newly_created_account}
-  end
-
-  test "can use assoc/3 in a factory to override associations" do
-    my_article = MyApp.ExMachina.create(:article, title: "So Deep")
-
-    comment = MyApp.ExMachina.create(:comment, article: my_article)
-
-    assert comment.article == my_article
+    assert "me-0@foo.com" == MyApp.Factories.build(:email).email
+    assert "me-1@foo.com" == MyApp.Factories.build(:email).email
   end
 
   test "factories can be defined without the attrs param" do
-    assert MyApp.ExMachina.build(:user) == MyApp.ExMachina.factory(:user)
+    assert MyApp.Factories.build(:user) == MyApp.Factories.factory(:user)
   end
 
   test "raises a helpful error if the factory is not defined" do
     assert_raise ExMachina.UndefinedFactory, "No factory defined for :foo", fn ->
-      MyApp.ExMachina.build(:foo)
-    end
-  end
-
-  test "fields_for/2 removes Ecto specific fields" do
-    assert MyApp.ExMachina.fields_for(:book) == %{
-      title: "Foo",
-      publisher_id: 1,
-    }
-  end
-
-  test "fields_for/2 raises when passed a map" do
-    assert_raise ArgumentError, fn ->
-      MyApp.ExMachina.fields_for(:user)
+      MyApp.Factories.build(:foo)
     end
   end
 
   test "build/2 returns the matching factory" do
-    assert MyApp.ExMachina.build(:user) == %{
+    assert MyApp.Factories.build(:user) == %{
       id: 3,
       name: "John Doe",
       admin: false
@@ -152,7 +54,7 @@ defmodule ExMachinaTest do
   end
 
   test "build/2 merges passed in options as keyword list" do
-    assert MyApp.ExMachina.build(:user, admin: true) == %{
+    assert MyApp.Factories.build(:user, admin: true) == %{
       id: 3,
       name: "John Doe",
       admin: true
@@ -160,51 +62,45 @@ defmodule ExMachinaTest do
   end
 
   test "build/2 merges passed in options as a map" do
-    assert MyApp.ExMachina.build(:user, admin: true) == %{
+    assert MyApp.Factories.build(:user, admin: true) == %{
       id: 3,
       name: "John Doe",
       admin: true
     }
   end
 
-  test "create/2 builds the factory and saves it in the repo" do
-    user = MyApp.ExMachina.create(:user, admin: true)
+  test "create/2 builds factory and performs save with user defined save_record/1" do
+    record = MyApp.Factories.create(:user)
 
-    assert user == %{id: 3, name: "John Doe", admin: true}
-    assert_received {:created, %{name: "John Doe", admin: true}}
+    created_record = %{admin: false, id: 3, name: "John Doe"}
+    assert record == created_record
+    assert_received {:custom_save, ^created_record}
   end
 
-  test "create/2 builds factory and performs custom save if repo is not set" do
-    record = MyApp.NonEctoFactories.create(:foo)
-
-    assert record == %{foo: :bar}
-    assert_received {:custom_save, %{foo: :bar}}
-  end
-
-  test "create/2 raises a helpful error if no repo and no custom function" do
+  test "create/2 raises a helpful error if save_record/1 is not defined" do
     assert_raise ExMachina.UndefinedSave, fn ->
       MyApp.NoSaveFunction.create(:foo)
     end
   end
 
   test "create_pair/2 creates the factory and saves it 2 times" do
-    users = MyApp.ExMachina.create_pair(:user, admin: true)
+    records = MyApp.Factories.create_pair(:user)
 
-    created_user = %{id: 3, name: "John Doe", admin: true}
-    assert users == [created_user, created_user]
-    assert_received {:created, ^created_user}
-    assert_received {:created, ^created_user}
-    refute_received {:created, _}
+    created_record = %{admin: false, id: 3, name: "John Doe"}
+    assert records == [created_record, created_record]
+    assert_received {:custom_save, ^created_record}
+    assert_received {:custom_save, ^created_record}
+    refute_received {:custom_save, _}
   end
 
   test "create_list/3 creates factory and saves it passed in number of times" do
-    users = MyApp.ExMachina.create_list(3, :user, admin: true)
+    records = MyApp.Factories.create_list(3, :user)
 
-    created_user = %{id: 3, name: "John Doe", admin: true}
-    assert users == [created_user, created_user, created_user]
-    assert_received {:created, ^created_user}
-    assert_received {:created, ^created_user}
-    assert_received {:created, ^created_user}
-    refute_received {:created, _}
+    created_record = %{admin: false, id: 3, name: "John Doe"}
+    assert records == [created_record, created_record, created_record]
+    assert_received {:custom_save, ^created_record}
+    assert_received {:custom_save, ^created_record}
+    assert_received {:custom_save, ^created_record}
+    refute_received {:custom_save, _}
   end
 end


### PR DESCRIPTION
This should make it easier to add other adapters in the future and
reduces the need for conditionals due to separation of concerns.