### PR TITLE
Fix Ecto tests. Make it easier to do the right thing with `assoc/3`

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -69,9 +69,14 @@ defmodule ExMachina.Ecto do
       assoc(attrs, :author, factory: :user)
   """
   def assoc(module, attrs, factory_name, opts \\ []) do
-    case Map.get(attrs, factory_name) do
-      nil -> create_assoc(module, factory_name, opts)
-      record -> record
+    assoc_id = "#{factory_name}_id" |> String.to_atom
+    if Map.has_key?(attrs, assoc_id) do
+      raise ArgumentError, "Set association with :#{factory_name} instead of :#{assoc_id}"
+    else
+      case Map.get(attrs, factory_name) do
+        nil -> create_assoc(module, factory_name, opts)
+        record -> record
+      end
     end
   end
 

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -105,6 +105,14 @@ defmodule ExMachina.EctoTest do
     assert_received {:created, ^newly_created_account}
   end
 
+  test "assoc/3 raises helpful error if setting the id directly" do
+    message = "Set association with :article instead of :article_id"
+    assert_raise ArgumentError, message, fn ->
+      MyApp.EctoFactories.create(:comment, article_id: 1)
+    end
+    refute_received {:custom_save, _}
+  end
+
   test "can use assoc/3 in a factory to override associations" do
     my_article = MyApp.EctoFactories.create(:article, title: "So Deep")
 

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -71,38 +71,38 @@ defmodule ExMachina.EctoTest do
   end
 
   test "save_record/1 passes the data to @repo.insert!" do
-    user = MyApp.EctoFactories.save_record(:user, admin: true)
+    record = MyApp.EctoFactories.save_record(%{foo: "bar"})
 
-    assert user == %{id: 3, name: "John Doe", admin: true}
-    assert_received {:created, %{name: "John Doe", admin: true}}
+    assert record == %{foo: "bar"}
+    assert_received {:created, %{foo: "bar"}}
   end
 
   test "assoc/3 returns the passed in key if it exists" do
     existing_account = %{id: 1, plan_type: "free"}
     attrs = %{account: existing_account}
 
-    assert MyApp.EctoFactories.assoc(MyApp.EctoFactories, attrs, :account) == existing_account
-    refute_received {:custom_save, _}
+    assert ExMachina.Ecto.assoc(MyApp.EctoFactories, attrs, :account) == existing_account
+    refute_received {:created, _}
   end
 
   test "assoc/3 creates and returns a factory if one was not in attrs" do
     attrs = %{}
 
-    user = MyApp.EctoFactories.assoc(MyApp.EctoFactories, attrs, :user)
+    user = ExMachina.Ecto.assoc(MyApp.EctoFactories, attrs, :user)
 
-    created_user = %{id: 3, name: "John Doe", admin: true}
+    created_user = %{id: 3, name: "John Doe", admin: false}
     assert user == created_user
-    assert_received {:custom_save, ^created_user}
+    assert_received {:created, ^created_user}
   end
 
   test "assoc/3 can specify a factory for the association" do
     attrs = %{}
 
-    account = MyApp.EctoFactories.assoc(MyApp.EctoFactories, attrs, :account, factory: :user)
+    account = ExMachina.Ecto.assoc(MyApp.EctoFactories, attrs, :account, factory: :user)
 
     newly_created_account = %{id: 3, admin: false, name: "John Doe"}
     assert account == newly_created_account
-    assert_received {:custom_save, ^newly_created_account}
+    assert_received {:created, ^newly_created_account}
   end
 
   test "can use assoc/3 in a factory to override associations" do


### PR DESCRIPTION
The rationale behind this is that it should be easy to do the right thing, and hard to do the wrong thing. Associations should be set using the name of the association and not the id. 

I believe this helpful for 2 reasons
1) It makes it so you don't accidentally create an associated record without meaning to
2) It makes it clear how you should set associations. I've seen plenty of projects that set factory associations with `user` or `user_id` depending on the dev. This aims to help fix that.