### PR TITLE
Handle has_one and has_many associations

### DIFF
--- a/priv/test_repo/migrations/20151016110321_create_packages_and_invoices.exs
+++ b/priv/test_repo/migrations/20151016110321_create_packages_and_invoices.exs
@@ -1,0 +1,17 @@
+defmodule ExMachina.TestRepo.Migrations.CreatePackagesAndInvoices do
+  use Ecto.Migration
+
+  def change do
+    create table(:invoices) do
+      add :title, :string
+      add :package_id, :integer
+    end
+    create table(:package_statuses) do
+      add :status, :string
+      add :package_id, :integer
+    end
+    create table(:packages) do
+      add :description, :string
+    end
+  end
+end

--- a/test/ex_machina/ecto_has_many_test.exs
+++ b/test/ex_machina/ecto_has_many_test.exs
@@ -1,0 +1,105 @@
+defmodule ExMachina.EctoHasManyTest do
+  use ExUnit.Case, async: false
+  alias ExMachina.TestRepo
+
+  setup_all do
+    Ecto.Adapters.SQL.begin_test_transaction(TestRepo, [])
+    on_exit fn -> Ecto.Adapters.SQL.rollback_test_transaction(TestRepo, []) end
+    :ok
+  end
+
+  setup do
+    Ecto.Adapters.SQL.restart_test_transaction(TestRepo, [])
+    :ok
+  end
+
+  defmodule Package do
+    use Ecto.Model
+    schema "packages" do
+      field :description, :string
+      has_many :statuses, ExMachina.EctoHasManyTest.PackageStatus
+    end
+  end
+
+  defmodule PackageStatus do
+    use Ecto.Model
+    schema "package_statuses" do
+      field :status, :string
+      belongs_to :package, Package
+    end
+  end
+
+  defmodule Invoice do
+    use Ecto.Model
+    schema "invoices" do
+      field :title, :string
+      belongs_to :package, Package
+    end
+  end
+
+  defmodule Factory do
+    use ExMachina.Ecto, repo: TestRepo
+
+    factory(:invalid_package) do
+      %Package{
+        description: "Invalid package without any statuses"
+      }
+    end
+
+    factory(:package) do
+      %Package{
+        description: "Package that just got ordered",
+        statuses: [
+          %PackageStatus{status: "ordered"}
+        ]
+      }
+    end
+
+    factory(:shipped_package) do
+      %Package{
+        description: "Package that got shipped",
+        statuses: [
+          %PackageStatus{status: "ordered"},
+          %PackageStatus{status: "sent"},
+          %PackageStatus{status: "shipped"}
+        ]
+      }
+    end
+
+    factory(:invoice) do
+      %Invoice{
+        title: "Invoice for shipped package",
+        package: assoc(:package, factory: :shipped_package)
+      }
+    end
+  end
+
+  test "create/1 creates model with `has_many` associations" do
+    package = Factory.create(:package)
+
+    assert %{statuses: [%{status: "ordered"}]} = package
+  end
+
+  test "create/2 creates model with overriden `has_many` associations" do
+    statuses = [
+      %PackageStatus{status: "ordered"},
+      %PackageStatus{status: "delayed"}
+    ]
+    package = Factory.create :package,
+      description: "Delayed package",
+      statuses: statuses
+
+    assert %{statuses: [%{status: "ordered"}, %{status: "delayed"}]} = package
+  end
+
+  test "create/1 creates model without `has_many` association specified" do
+    package = Factory.create(:invalid_package)
+    assert package
+  end
+
+  test "create/1 creates model with `belongs_to` having `has_many` associations" do
+    invoice = Factory.create(:invoice)
+
+    assert %{title: "Invoice for shipped package", package_id: 1} = invoice
+  end
+end

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -1,5 +1,5 @@
 defmodule ExMachina.EctoTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   alias ExMachina.TestRepo
 
   setup_all do
@@ -144,6 +144,12 @@ defmodule ExMachina.EctoTest do
 
     assert_raise ArgumentError, message, fn ->
       Factory.save_record(%Article{title: "Ecto is Awesome", author: author})
+    end
+  end
+
+  test "save_record/1 raises unless Ecto.Model is passed" do
+    assert_raise ArgumentError, ~r"not Ecto model", fn ->
+      Factory.save_record(%{foo: "bar"})
     end
   end
 


### PR DESCRIPTION
Ecto.Repo.insert! only handles associations when changeset is passed as
argument. Prior to insertion, Ecto.Model is thus converted to
Ecto.Changeset. Related to #14.