### PR TITLE
Add Ecto dep to ExMachina.Ecto

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -1,5 +1,7 @@
 defmodule ExMachina.Ecto do
   defmacro __using__(opts) do
+    verify_ecto_dep
+
     quote do
       use ExMachina
 
@@ -16,6 +18,13 @@ defmodule ExMachina.Ecto do
       def save_record(record) do
         ExMachina.Ecto.save_record(__MODULE__, @repo, record)
       end
+    end
+  end
+
+  defp verify_ecto_dep do
+    unless Code.ensure_loaded?(Ecto) do
+      raise "You tried to use ExMachina.Ecto, but the Ecto module is not loaded. " <>
+        "Please add ecto to your dependencies."
     end
   end
 
@@ -85,7 +94,7 @@ defmodule ExMachina.Ecto do
   @doc """
   Saves a record using `Repo.insert!` when `create` is called.
   """
-  def save_record(module, repo, record) do
+  def save_record(_module, repo, record) do
     if repo do
       repo.insert!(record)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,8 @@ defmodule ExMachina.Mixfile do
   defp deps do
     [
       {:ex_doc, "~> 0.9", only: :dev},
-      {:earmark, ">= 0.0.0", only: :dev}
+      {:earmark, ">= 0.0.0", only: :dev},
+      {:ecto, "~> 1.0", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,5 @@
-%{"earmark": {:hex, :earmark, "0.1.17"},
-  "ex_doc": {:hex, :ex_doc, "0.9.0"}}
+%{"decimal": {:hex, :decimal, "1.1.0"},
+  "earmark": {:hex, :earmark, "0.1.17"},
+  "ecto": {:hex, :ecto, "1.0.3"},
+  "ex_doc": {:hex, :ex_doc, "0.9.0"},
+  "poolboy": {:hex, :poolboy, "1.5.1"}}


### PR DESCRIPTION
This PR adds explicit dependency on Ecto in dev and test envs. It also raises error is user of the library tries to `use ExMachina.Ecto` while not having `Ecto` module.

As Ecto is added as test dependence, tests were refactored to use Ecto.Model instead of fakes.