### PR TITLE
Allow chaining with built records

### DIFF
--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -55,6 +55,10 @@ defmodule ExMachina do
         ExMachina.build_list(__MODULE__, number_of_factories, factory_name, attrs)
       end
 
+      def create(built_record) when is_map(built_record) do
+        __MODULE__.save_record(built_record)
+      end
+
       def create(factory_name, attrs \\ %{}) do
         ExMachina.create(__MODULE__, factory_name, attrs)
       end

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -97,6 +97,15 @@ defmodule ExMachinaTest do
     assert_received {:custom_save, ^created_record}
   end
 
+  test "create/2 saves built records" do
+    record = MyApp.Factories.build(:user) |> MyApp.Factories.create
+
+    created_record = %{admin: false, id: 3, name: "John Doe"}
+    assert record == created_record
+    assert_received {:custom_save, ^created_record}
+    refute_received {:custom_save}
+  end
+
   test "create/2 raises a helpful error if save_record/1 is not defined" do
     assert_raise ExMachina.UndefinedSave, fn ->
       MyApp.NoSaveFunction.create(:foo)


### PR DESCRIPTION
This will allow things like:

```
build(:user, name: "john") |> on_free_trial |> create |> add_comment(title: "toto")
```

So that you can easily modify the built record, then call create and do `has_many/has_one` relationships with the saved record. I will be adding the functionality to not save associations on build in the next PR, which should make this a bit more robust