### PR TITLE
Cleaning up warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ end
 ## Using without Ecto
 
 You can use ExMachina without Ecto, by using just the `build` function, or by
-defining `save_function/1` in your module.
+defining `save_record/1` in your module.
 
 ```elixir
 defmodule MyApp.JsonFactories do

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -188,7 +188,9 @@ defmodule ExMachina do
   end
 
   defmacro __before_compile__(_env) do
-    quote do
+    # We are using line -1 because we don't want warnings coming from
+    # save_record/1 when someone defines there own save_recod/1 function.
+    quote line: -1 do
       @doc """
       Raises a helpful error if no factory is defined.
       """
@@ -226,7 +228,7 @@ defmodule ExMachina do
               %User{name: "John"}
             end
 
-            def save_function(record) do
+            def save_record(record) do
               # Poison is a library for working with JSON
               Poison.encode!(record)
             end

--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -14,7 +14,7 @@ defmodule ExMachina.Ecto do
         end
 
         def save_record(record) do
-          ExMachina.Ecto.save_record(__MODULE__, @repo, record)
+          ExMachina.Ecto.save_record(@repo, record)
         end
       end
     else
@@ -106,7 +106,7 @@ defmodule ExMachina.Ecto do
   @doc """
   Saves a record using `Repo.insert!` when `create` is called.
   """
-  def save_record(_module, repo, record) do
+  def save_record(repo, record) do
     if repo do
       repo.insert!(record)
     end


### PR DESCRIPTION
* Removes warning when defining custom save_record/1 function
* Removes unnecessary `module` param in `ExMachina.Ecto.save_record`
* Corrects docs. `save_function/1` to `save_function/2`

Closes #22