### PR TITLE
Add note about importing with Phoenix

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import Ecto.Model, except: [build: 2]
 
 ```elixir
 # test/factories.ex
-defmodule MyApp.Factories do
+defmodule MyApp.Factory do
   # MyApp.Repo is an Ecto Repo.
   # It will automatically be used when calling `create`
   use ExMachina.Ecto, repo: MyApp.Repo
@@ -78,7 +78,7 @@ Then use it in your tests. This is an example with Phoenix.
 defmodule MyApp.MyModuleTest do
   use MyApp.ConnCase
   # You can also import this in your MyApp.ConnCase if using Phoenix
-  import MyApp.Factories
+  import MyApp.Factory
 
   test "shows comments for an article" do
     conn = conn()
@@ -121,7 +121,7 @@ This gives you the power to call `create` and save to Ecto, or call `build_json`
 or `create_json` to return encoded JSON objects.
 
 ```elixir
-defmodule MyApp.Factories do
+defmodule MyApp.Factory do
   use ExMachina.Ecto, repo: MyApp.Repo
 
   factory :user do

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In `mix.exs`, add the ExMachina dependency:
 
 ```elixir
 def deps do
-  [{:ex_machina, "~> 0.2"}]
+  [{:ex_machina, "~> 0.3"}]
 end
 ```
 
@@ -23,6 +23,23 @@ end
 defp app_list(:test), do: [:ex_machina | app_list]
 defp app_list(_),  do: app_list
 defp app_list,  do: [:logger]
+```
+
+## Using with Phoenix and Ecto
+
+There is nothing special you need to do with Phoenix unless you decide to
+`import` your factory module.
+
+By default Phoenix `import`s `Ecto.Model` in the generated `ConnCase` and
+`ModelCase`  modules (found in `test/support/conn_case.ex` and
+`test/support/model_case.ex`). To import your factory we recommend excluding
+`build/2` or aliasing your factory instead.
+
+```elixir
+# in test/support/conn_case|model_case.ex
+
+# Add `except: [build: 2] to the `Ecto.Model` import
+import Ecto.Model, except: [build: 2]
 ```
 
 ## Using with Ecto

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -185,7 +185,7 @@ defmodule ExMachina do
 
       ## Examples
 
-          defmodule MyApp.Factories do
+          defmodule MyApp.Factory do
             use ExMachina.Ecto, repo: MyApp.Repo
 
             factory :user do
@@ -194,7 +194,7 @@ defmodule ExMachina do
           end
 
           # Will build and save the record to the MyApp.Repo
-          MyApp.Factories.create(:user)
+          MyApp.Factory.create(:user)
 
           defmodule MyApp.JsonFactories do
             # Note, we are not using ExMachina.Ecto

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -1,7 +1,7 @@
 defmodule ExMachinaTest do
   use ExUnit.Case, async: true
 
-  defmodule MyApp.Factories do
+  defmodule MyApp.Factory do
     use ExMachina
 
     factory :user do
@@ -33,18 +33,18 @@ defmodule ExMachinaTest do
   end
 
   test "sequence/2 sequences a value" do
-    assert "me-0@foo.com" == MyApp.Factories.build(:email).email
-    assert "me-1@foo.com" == MyApp.Factories.build(:email).email
+    assert "me-0@foo.com" == MyApp.Factory.build(:email).email
+    assert "me-1@foo.com" == MyApp.Factory.build(:email).email
   end
 
   test "raises a helpful error if the factory is not defined" do
     assert_raise ExMachina.UndefinedFactory, "No factory defined for :foo", fn ->
-      MyApp.Factories.build(:foo)
+      MyApp.Factory.build(:foo)
     end
   end
 
   test "build/2 returns the matching factory" do
-    assert MyApp.Factories.build(:user) == %{
+    assert MyApp.Factory.build(:user) == %{
       id: 3,
       name: "John Doe",
       admin: false
@@ -52,7 +52,7 @@ defmodule ExMachinaTest do
   end
 
   test "build/2 merges passed in options as keyword list" do
-    assert MyApp.Factories.build(:user, admin: true) == %{
+    assert MyApp.Factory.build(:user, admin: true) == %{
       id: 3,
       name: "John Doe",
       admin: true
@@ -60,7 +60,7 @@ defmodule ExMachinaTest do
   end
 
   test "build/2 merges passed in options as a map" do
-    assert MyApp.Factories.build(:user, admin: true) == %{
+    assert MyApp.Factory.build(:user, admin: true) == %{
       id: 3,
       name: "John Doe",
       admin: true
@@ -68,7 +68,7 @@ defmodule ExMachinaTest do
   end
 
   test "build_pair/2 builds 2 factories" do
-    records = MyApp.Factories.build_pair(:user, admin: true)
+    records = MyApp.Factory.build_pair(:user, admin: true)
 
     expected_record = %{
       id: 3,
@@ -79,7 +79,7 @@ defmodule ExMachinaTest do
   end
 
   test "build_list/3 builds the factory the passed in number of times" do
-    records = MyApp.Factories.build_list(3, :user, admin: true)
+    records = MyApp.Factory.build_list(3, :user, admin: true)
 
     expected_record = %{
       id: 3,
@@ -90,7 +90,7 @@ defmodule ExMachinaTest do
   end
 
   test "create/2 builds factory and performs save with user defined save_record/1" do
-    record = MyApp.Factories.create(:user)
+    record = MyApp.Factory.create(:user)
 
     created_record = %{admin: false, id: 3, name: "John Doe"}
     assert record == created_record
@@ -98,7 +98,7 @@ defmodule ExMachinaTest do
   end
 
   test "create/2 saves built records" do
-    record = MyApp.Factories.build(:user) |> MyApp.Factories.create
+    record = MyApp.Factory.build(:user) |> MyApp.Factory.create
 
     created_record = %{admin: false, id: 3, name: "John Doe"}
     assert record == created_record
@@ -113,7 +113,7 @@ defmodule ExMachinaTest do
   end
 
   test "create_pair/2 creates the factory and saves it 2 times" do
-    records = MyApp.Factories.create_pair(:user)
+    records = MyApp.Factory.create_pair(:user)
 
     created_record = %{admin: false, id: 3, name: "John Doe"}
     assert records == [created_record, created_record]
@@ -123,7 +123,7 @@ defmodule ExMachinaTest do
   end
 
   test "create_list/3 creates factory and saves it passed in number of times" do
-    records = MyApp.Factories.create_list(3, :user)
+    records = MyApp.Factory.create_list(3, :user)
 
     created_record = %{admin: false, id: 3, name: "John Doe"}
     assert records == [created_record, created_record, created_record]


### PR DESCRIPTION
Even if the Phoenix team decides not to import `build` by default it might make sense to include this since people that already have a generated Phoenix application would have the `Eco.Model` import.