### PR TITLE
Don't save associations in build

### DIFF
--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -56,7 +56,7 @@ defmodule ExMachina do
       end
 
       def create(built_record) when is_map(built_record) do
-        __MODULE__.save_record(built_record)
+        ExMachina.create(__MODULE__, built_record)
       end
 
       def create(factory_name, attrs \\ %{}) do
@@ -157,6 +157,11 @@ defmodule ExMachina do
       # Saves and returns %{name: "John Doe", admin: true}
       create(:user, admin: true)
   """
+
+  def create(module, built_record) when is_map(built_record) do
+    module.save_record(built_record)
+  end
+
   def create(module, factory_name, attrs \\ %{}) do
     ExMachina.build(module, factory_name, attrs) |> module.save_record
   end

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -42,6 +42,34 @@ defmodule ExMachina do
       @before_compile unquote(__MODULE__)
 
       import ExMachina, only: [sequence: 2, factory: 2]
+
+      def build(factory_name, attrs \\ %{}) do
+        ExMachina.build(__MODULE__, factory_name, attrs)
+      end
+
+      def build_pair(factory_name, attrs \\ %{}) do
+        ExMachina.build_pair(__MODULE__, factory_name, attrs)
+      end
+
+      def build_list(number_of_factories, factory_name, attrs \\ %{}) do
+        ExMachina.build_list(__MODULE__, number_of_factories, factory_name, attrs)
+      end
+
+      def create(built_record) when is_map(built_record) do
+        __MODULE__.save_record(built_record)
+      end
+
+      def create(factory_name, attrs \\ %{}) do
+        ExMachina.create(__MODULE__, factory_name, attrs)
+      end
+
+      def create_pair(factory_name, attrs \\ %{}) do
+        ExMachina.create_pair(__MODULE__, factory_name, attrs)
+      end
+
+      def create_list(number_of_factories, factory_name, attrs \\ %{}) do
+        ExMachina.create_list(__MODULE__, number_of_factories, factory_name, attrs)
+      end
     end
   end
 
@@ -68,6 +96,97 @@ defmodule ExMachina do
   """
   def sequence(name, formatter), do: ExMachina.Sequence.next(name, formatter)
 
+  @doc """
+  Builds a factory with the passed in factory_name and attrs
+
+  ## Example
+
+      factory :user do
+        %{name: "John Doe", admin: false}
+      end
+
+      # Returns %{name: "John Doe", admin: true}
+      build(:user, admin: true)
+  """
+  def build(module, factory_name, attrs \\ %{}) do
+    attrs = Enum.into(attrs, %{})
+    module.factory(factory_name, attrs) |> Map.merge(attrs)
+  end
+
+  @doc """
+  Builds and returns 2 records with the passed in factory_name and attrs
+
+  ## Example
+
+      # Returns a list of 2 users
+      build_pair(:user)
+  """
+  def build_pair(module, factory_name, attrs \\ %{}) do
+    ExMachina.build_list(module, 2, factory_name, attrs)
+  end
+
+  @doc """
+  Builds and returns X records with the passed in factory_name and attrs
+
+  ## Example
+
+      # Returns a list of 3 users
+      build_list(3, :user)
+  """
+  def build_list(module, number_of_factories, factory_name, attrs \\ %{}) do
+    Enum.map(1..number_of_factories, fn(_) ->
+      ExMachina.build(module, factory_name, attrs)
+    end)
+  end
+
+  @doc """
+  Builds and saves a factory with the passed in factory_name
+
+  If using ExMachina.Ecto it will use the Ecto Repo passed in to save the
+  record automatically.
+
+  If you are not using ExMachina.Ecto, you need to define a `save_record/1`
+  function in your module. See `save_record` docs for more information.
+
+  ## Example
+
+      factory :user do
+        %{name: "John Doe", admin: false}
+      end
+
+      # Saves and returns %{name: "John Doe", admin: true}
+      create(:user, admin: true)
+  """
+  def create(module, factory_name, attrs \\ %{}) do
+    ExMachina.build(module, factory_name, attrs) |> module.save_record
+  end
+
+  @doc """
+  Creates and returns 2 records with the passed in factory_name and attrs
+
+  ## Example
+
+      # Returns a list of 2 saved users
+      create_pair(:user)
+  """
+  def create_pair(module, factory_name, attrs \\ %{}) do
+    ExMachina.create_list(module, 2, factory_name, attrs)
+  end
+
+  @doc """
+  Creates and returns X records with the passed in factory_name and attrs
+
+  ## Example
+
+      # Returns a list of 3 saved users
+      create_list(3, :user)
+  """
+  def create_list(module, number_of_factories, factory_name, attrs \\ %{}) do
+    Enum.map(1..number_of_factories, fn(_) ->
+      ExMachina.create(module, factory_name, attrs)
+    end)
+  end
+
   defmacro __before_compile__(_env) do
     # We are using line -1 because we don't want warnings coming from
     # save_record/1 when someone defines there own save_recod/1 function.
@@ -77,101 +196,6 @@ defmodule ExMachina do
       """
       def factory(factory_name, _) do
         raise UndefinedFactory, factory_name
-      end
-
-      @doc """
-      Builds a factory with the passed in factory_name and attrs
-
-      ## Example
-
-          factory :user do
-            %{name: "John Doe", admin: false}
-          end
-
-          # Returns %{name: "John Doe", admin: true}
-          build(:user, admin: true)
-      """
-      def build(factory_name, attrs \\ %{}) do
-        attrs = Enum.into(attrs, %{})
-        __MODULE__.factory(factory_name, attrs) |> Map.merge(attrs)
-      end
-
-      @doc """
-      Builds and returns 2 records with the passed in factory_name and attrs
-
-      ## Example
-
-          # Returns a list of 2 users
-          build_pair(:user)
-      """
-      def build_pair(factory_name, attrs \\ %{}) do
-        build_list(2, factory_name, attrs)
-      end
-
-      @doc """
-      Builds and returns X records with the passed in factory_name and attrs
-
-      ## Example
-
-          # Returns a list of 3 users
-          build_list(3, :user)
-      """
-      def build_list(number_of_factories, factory_name, attrs \\ %{}) do
-        Enum.map(1..number_of_factories, fn(_) ->
-          build(factory_name, attrs)
-        end)
-      end
-
-      @doc """
-      Builds and saves a factory with the passed in factory_name
-
-      If using ExMachina.Ecto it will use the Ecto Repo passed in to save the
-      record automatically.
-
-      If you are not using ExMachina.Ecto, you need to define a `save_record/1`
-      function in your module. See `save_record` docs for more information.
-
-      ## Example
-
-          factory :user do
-            %{name: "John Doe", admin: false}
-          end
-
-          # Saves and returns %{name: "John Doe", admin: true}
-          create(:user, admin: true)
-      """
-      def create(built_record) when is_map(built_record) do
-        built_record |> save_record
-      end
-
-      def create(factory_name, attrs \\ %{}) do
-        build(factory_name, attrs) |> save_record
-      end
-
-      @doc """
-      Creates and returns 2 records with the passed in factory_name and attrs
-
-      ## Example
-
-          # Returns a list of 2 saved users
-          create_pair(:user)
-      """
-      def create_pair(factory_name, attrs \\ %{}) do
-        create_list(2, factory_name, attrs)
-      end
-
-      @doc """
-      Creates and returns X records with the passed in factory_name and attrs
-
-      ## Example
-
-          # Returns a list of 3 saved users
-          create_list(3, :user)
-      """
-      def create_list(number_of_factories, factory_name, attrs \\ %{}) do
-        Enum.map(1..number_of_factories, fn(_) ->
-          create(factory_name, attrs)
-        end)
       end
 
       @doc """

--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -97,10 +97,10 @@ defmodule ExMachina.Ecto do
   end
 
   defp create_assoc(module, _factory_name, factory: factory_name) do
-    module.create(factory_name)
+    ExMachina.create(module, factory_name)
   end
   defp create_assoc(module, factory_name, _opts) do
-    module.create(factory_name)
+    ExMachina.create(module, factory_name)
   end
 
   @doc """

--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -73,7 +73,7 @@ defmodule ExMachina.Ecto do
   end
 
   @doc """
-  Gets a factory from the passed in attrs, or creates if none is present
+  Gets a factory from the passed in attrs, or builds if none is present
 
   ## Examples
 
@@ -82,25 +82,25 @@ defmodule ExMachina.Ecto do
       assoc(:user)
 
       attrs = %{}
-      # Creates and returns new instance based on :user factory
+      # Builds and returns new instance based on :user factory
       assoc(:user)
 
       attrs = %{}
-      # Creates and returns new instance based on :user factory
+      # Builds and returns new instance based on :user factory
       assoc(:author, factory: :user)
   """
   def assoc(module, attrs, factory_name, opts \\ []) do
     case Map.get(attrs, factory_name) do
-      nil -> create_assoc(module, factory_name, opts)
+      nil -> build_assoc(module, factory_name, opts)
       record -> record
     end
   end
 
-  defp create_assoc(module, _factory_name, factory: factory_name) do
-    ExMachina.create(module, factory_name)
+  defp build_assoc(module, _factory_name, factory: factory_name) do
+    ExMachina.build(module, factory_name)
   end
-  defp create_assoc(module, factory_name, _opts) do
-    ExMachina.create(module, factory_name)
+  defp build_assoc(module, factory_name, _opts) do
+    ExMachina.build(module, factory_name)
   end
 
   @doc """

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -123,15 +123,14 @@ defmodule ExMachina.EctoTest do
     TestRepo.all(User) == []
   end
 
-  test "assoc/3 creates and returns a factory if one was not in attrs" do
+  test "assoc/3 builds and returns a factory if one was not in attrs" do
     attrs = %{}
 
     user = ExMachina.Ecto.assoc(EctoFactories, attrs, :user)
 
-    newly_created_user = TestRepo.one!(User)
-    assert newly_created_user.name == "John Doe"
-    refute newly_created_user.admin
-    assert user == newly_created_user
+    refute TestRepo.one(User)
+    assert user.name == "John Doe"
+    refute user.admin
   end
 
   test "assoc/3 can specify a factory for the association" do
@@ -139,8 +138,8 @@ defmodule ExMachina.EctoTest do
 
     account = ExMachina.Ecto.assoc(EctoFactories, attrs, :account, factory: :user)
 
-    new_user = TestRepo.one!(User)
-    assert account == new_user
+    assert account == EctoFactories.build(:user)
+    refute TestRepo.one(User)
   end
 
   test "can use assoc/3 in a factory to override associations" do


### PR DESCRIPTION
This PR makes it so records, including associations, are only saved in `save_record`. There is no reason to save the records on the build step, so this will save unnecessary writes, while making build more intuitive.