### PR TITLE
Ignore associations that are not set

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -20,5 +20,6 @@ use Mix.Config
 # by uncommenting the line below and defining dev.exs, test.exs and such.
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
-
-import_config "#{Mix.env}.exs"
+if Mix.env == :test do
+  import_config "test.exs"
+end

--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -122,6 +122,7 @@ defmodule ExMachina.Ecto do
           put_assoc(record, association_name, association)
         %{__meta__: %{state: :loaded}} ->
           put_assoc(record, association_name, association)
+        %Ecto.Association.NotLoaded{} -> record
         _ ->
           raise ArgumentError,
             "expected #{inspect(association_name)} to be an Ecto struct but got #{inspect(association)}"

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -127,6 +127,13 @@ defmodule ExMachina.EctoTest do
     assert TestRepo.one(User)
   end
 
+  test "save_record/1 ignores associations that are not set" do
+    article = Factory.save_record(%Article{title: "Ecto is Awesome"})
+
+    assert TestRepo.get_by(Article, title: "Ecto is Awesome")
+    assert TestRepo.all(User) == []
+  end
+
   test "save_record/1 raises for associated records that are not Ecto structs" do
     author = %{}
 

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -128,7 +128,9 @@ defmodule ExMachina.EctoTest do
   end
 
   test "save_record/1 ignores associations that are not set" do
-    article = Factory.save_record(%Article{title: "Ecto is Awesome"})
+    Factory.save_record(
+      %Article{title: "Ecto is Awesome", author: %Ecto.Association.NotLoaded{}}
+    )
 
     assert TestRepo.get_by(Article, title: "Ecto is Awesome")
     assert TestRepo.all(User) == []


### PR DESCRIPTION
This fixes an error where a factory has an association, but the record
is not set in the factory definition or passed in when creating the
factory. Since associations are structs of type
`Ecto.Association.NotLoaded`, we can ignore these and return the record
as is.