### PR TITLE
Fix association bug

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -132,6 +132,9 @@ defmodule ExMachina.Ecto do
 
   defp put_assoc(record, association_name, association) do
     association_id = "#{association_name}_id" |> String.to_atom
-    Map.put(record, association_id, association.id)
+
+    record
+    |> Map.put(association_id, association.id)
+    |> Map.put(association_name, association)
   end
 end

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -107,10 +107,11 @@ defmodule ExMachina.EctoTest do
     assert model == new_user
   end
 
-  test "save_record/1 saves associated records and sets the association id" do
+  test "save_record/1 saves associated records and sets the association and association id" do
     author = Factory.build(:user)
     article = Factory.save_record(%Article{title: "Ecto is Awesome", author: author})
 
+    assert article.author == TestRepo.one(User)
     assert article.author_id == 1
     assert article.title == "Ecto is Awesome"
     assert TestRepo.get_by(Article, title: "Ecto is Awesome", author_id: 1)


### PR DESCRIPTION
Before this was only setting the association's id when saving a built
record, but that meant that the association still had the built record,
not the newly saved one. This makes sure that `put_assoc` set both the
id, and the associated record