### PR TITLE
Return to using functions for factory definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,24 +39,24 @@ defmodule MyApp.Factory do
   # without Ecto
   use ExMachina
 
-  factory :user do
+  def factory(:user, _attrs) do
     %User{
       name: "Jane Smith",
       email: sequence(:email, &"email-#{&1}@example.com"),
     }
   end
 
-  factory :article do
+  def factory(:article, attrs) do
     %Article{
       title: "Use ExMachina!",
-      author: assoc(:author, factory: :user), # only available in ExMachina.Ecto
+      author: assoc(attrs, :author, factory: :user), # only available in ExMachina.Ecto
     }
   end
 
-  factory :comment do
+  def factory(:comment, attrs) do
     %Comment{
       text: "It's great!",
-      article: assoc(:article),
+      article: assoc(attrs, :article),
     }
   end
 end
@@ -145,7 +145,7 @@ defining `save_record/1` in your module.
 defmodule MyApp.JsonFactory do
   use ExMachina
 
-  factory :user do
+  def factory(:user, _attrs) do
     %User{name: "John"}
   end
 
@@ -167,7 +167,7 @@ or `create_json` to return encoded JSON objects.
 defmodule MyApp.Factory do
   use ExMachina.Ecto, repo: MyApp.Repo
 
-  factory :user do
+  def factory(:user, _attrs) do
     %User{name: "John"}
   end
 

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -73,13 +73,19 @@ defmodule ExMachina do
     end
   end
 
-  defmacro factory(factory_name, do: block) do
-    quote do
-      def factory(unquote(factory_name), var!(attrs)) do
-        !var!(attrs) # Removes unused variable warning if attrs wasn't used
-        unquote(block)
+  defmacro factory(factory_name, do: _block) do
+    raise """
+    The factory and assoc macros have been removed. Please use regular
+    functions instead.
+
+      def factory(#{factory_name}, attrs) do
+        %{
+          ...
+          some_assoc: assoc(attrs, :some_assoc)
+          ...
+        }
       end
-    end
+    """
   end
 
   @doc """
@@ -87,7 +93,7 @@ defmodule ExMachina do
 
   ## Examples
 
-      factory :user do
+      def factory(:user, _attrs) do
         %{
           # Will generate "me-0@example.com" then "me-1@example.com", etc.
           email: sequence(:email, &"me-\#{&1}@foo.com")
@@ -101,7 +107,7 @@ defmodule ExMachina do
 
   ## Example
 
-      factory :user do
+      def factory(:user, _attrs) do
         %{name: "John Doe", admin: false}
       end
 
@@ -150,7 +156,7 @@ defmodule ExMachina do
 
   ## Example
 
-      factory :user do
+      def factory(:user, _attrs) do
         %{name: "John Doe", admin: false}
       end
 
@@ -199,7 +205,7 @@ defmodule ExMachina do
       @doc """
       Raises a helpful error if no factory is defined.
       """
-      def factory(factory_name, _) do
+      def factory(factory_name, _attrs) do
         raise UndefinedFactory, factory_name
       end
 
@@ -217,7 +223,7 @@ defmodule ExMachina do
           defmodule MyApp.Factory do
             use ExMachina.Ecto, repo: MyApp.Repo
 
-            factory :user do
+            def factory(:user, _attrs) do
               %User{name: "John"}
             end
           end
@@ -229,7 +235,7 @@ defmodule ExMachina do
             # Note, we are not using ExMachina.Ecto
             use ExMachina
 
-            factory :user do
+            def factory(:user, _attrs) do
               %User{name: "John"}
             end
 

--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -5,8 +5,6 @@ defmodule ExMachina.Ecto do
       quote do
         use ExMachina
 
-        import ExMachina.Ecto, only: [assoc: 1, assoc: 2]
-
         @repo unquote(repo)
 
         def fields_for(factory_name, attrs \\ %{}) do
@@ -16,6 +14,10 @@ defmodule ExMachina.Ecto do
         def save_record(record) do
           ExMachina.Ecto.save_record(__MODULE__, @repo, record)
         end
+
+        defp assoc(attrs, factory_name, opts \\ []) do
+          ExMachina.Ecto.assoc(__MODULE__, attrs, factory_name, opts)
+        end
       end
     else
       raise ArgumentError,
@@ -24,12 +26,6 @@ defmodule ExMachina.Ecto do
 
         use ExMachina.Ecto, repo: MyApp.Repo
         """
-    end
-  end
-
-  defmacro assoc(factory_name, opts \\ []) do
-    quote do
-      ExMachina.Ecto.assoc(__MODULE__, var!(attrs), unquote(factory_name), unquote(opts))
     end
   end
 
@@ -50,7 +46,7 @@ defmodule ExMachina.Ecto do
 
   ## Example
 
-      factory :user do
+      def factory(:user, _attrs) do
         %MyApp.User{name: "John Doe", admin: false}
       end
 

--- a/test/ex_machina/ecto_has_many_test.exs
+++ b/test/ex_machina/ecto_has_many_test.exs
@@ -29,7 +29,7 @@ defmodule ExMachina.EctoHasManyTest do
   defmodule Factory do
     use ExMachina.Ecto, repo: TestRepo
 
-    factory(:package) do
+    def factory(:package, _attrs) do
       %Package{
         description: "Package that just got ordered",
         statuses: [
@@ -38,7 +38,7 @@ defmodule ExMachina.EctoHasManyTest do
       }
     end
 
-    factory(:shipped_package) do
+    def factory(:shipped_package, _attrs) do
       %Package{
         description: "Package that got shipped",
         statuses: [
@@ -49,16 +49,16 @@ defmodule ExMachina.EctoHasManyTest do
       }
     end
 
-    factory(:package_status) do
+    def factory(:package_status, _attrs) do
       %PackageStatus{
         status: "ordered"
       }
     end
 
-    factory(:invoice) do
+    def factory(:invoice, attrs) do
       %Invoice{
         title: "Invoice for shipped package",
-        package: assoc(:package, factory: :shipped_package)
+        package: assoc(attrs, :package, factory: :shipped_package)
       }
     end
   end

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -30,14 +30,14 @@ defmodule ExMachina.EctoTest do
   defmodule Factory do
     use ExMachina.Ecto, repo: TestRepo
 
-    factory :user do
+    def factory(:user, _attrs) do
       %User{
         name: "John Doe",
         admin: false
       }
     end
 
-    factory :user_map do
+    def factory(:user_map, _attrs) do
       %{
         id: 3,
         name: "John Doe",
@@ -45,18 +45,18 @@ defmodule ExMachina.EctoTest do
       }
     end
 
-    factory :article do
+    def factory(:article, attrs) do
       %Article{
         title: "My Awesome Article",
-        author: assoc(:author, factory: :user)
+        author: assoc(attrs, :author, factory: :user)
       }
     end
 
-    factory :comment do
+    def factory(:comment, attrs) do
       %Comment{
         body: "Great article!",
-        article: assoc(:article),
-        user: assoc(:user)
+        article: assoc(attrs, :article),
+        user: assoc(attrs, :user)
       }
     end
   end

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -4,7 +4,7 @@ defmodule ExMachinaTest do
   defmodule Factory do
     use ExMachina
 
-    factory :user do
+    def factory(:user, _attrs) do
       %{
         id: 3,
         name: "John Doe",
@@ -12,7 +12,7 @@ defmodule ExMachinaTest do
       }
     end
 
-    factory :email do
+    def factory(:email, _attrs) do
       %{
         email: sequence(:email, &"me-#{&1}@foo.com")
       }
@@ -27,7 +27,7 @@ defmodule ExMachinaTest do
   defmodule NoSaveFunction do
     use ExMachina
 
-    factory(:foo) do
+    def factory(:foo, _attrs) do
       %{foo: :bar}
     end
   end


### PR DESCRIPTION
Functions have less complexity and less magic than normal functions.

The functional approach also provides access to the `attrs` hash, which
allows you to utilize it in your factory definition:

    def factory :user, attrs do
      modified_attrs = attrs |> modify_attrs
      %{
        name: "Foobar",
        accounts: assoc(modified_attrs, :accounts),
      }
    end