### PR TITLE
Fix intermittent failure

### DIFF
--- a/test/ex_machina/ecto_has_many_test.exs
+++ b/test/ex_machina/ecto_has_many_test.exs
@@ -1,5 +1,5 @@
 defmodule ExMachina.EctoHasManyTest do
-  use ExMachina.EctoCase, async: false
+  use ExMachina.EctoCase
   alias ExMachina.TestRepo
 
   defmodule Package do

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -1,5 +1,5 @@
 defmodule ExMachina.EctoTest do
-  use ExMachina.EctoCase, async: false
+  use ExMachina.EctoCase
   alias ExMachina.TestRepo
 
   defmodule User do

--- a/test/ex_machina/sequence_test.exs
+++ b/test/ex_machina/sequence_test.exs
@@ -1,5 +1,5 @@
 defmodule ExMachina.SequenceTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   alias ExMachina.Sequence
 

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -1,5 +1,5 @@
 defmodule ExMachinaTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   defmodule Factory do
     use ExMachina


### PR DESCRIPTION
Some of the other tests are running asynchronously and were causing
issues if they both used the same sequence name (in this case `email`).
Running the tests synchronously should fix the issue.

The tests are still plenty fast. Once Ecto supports concurrent tests, we may want to rethink the Sequence module so that it keeps sequences *per process* so others don't run into this issue with their tests. Fixes #44 