### PR TITLE
Tests for saving embedded Ecto models

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule ExMachina.Mixfile do
     [
       {:ex_doc, "~> 0.9", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},
-      {:ecto, "~> 1.0", only: :test},
+      {:ecto, "~> 1.0", only: [:dev, :test]},
       {:sqlite_ecto, "~> 1.0.0", only: :test}
     ]
   end

--- a/priv/test_repo/migrations/20151030144844_add_settings_to_users.exs
+++ b/priv/test_repo/migrations/20151030144844_add_settings_to_users.exs
@@ -1,0 +1,9 @@
+defmodule ExMachina.TestRepo.Migrations.AddSettingsToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :settings, :map
+    end
+  end
+end

--- a/test/ex_machina/ecto_embeds_test.exs
+++ b/test/ex_machina/ecto_embeds_test.exs
@@ -1,0 +1,55 @@
+defmodule ExMachina.EctoEmbedsTest do
+  use ExMachina.EctoCase
+  alias ExMachina.TestRepo
+
+  defmodule User do
+    use Ecto.Model
+    schema "users" do
+      field :name, :string
+      field :admin, :boolean
+      embeds_one :settings, ExMachina.EctoEmbedsTest.Settings
+    end
+  end
+
+  defmodule Settings do
+    use Ecto.Model
+    embedded_schema do
+      field :email_signature
+      field :send_emails, :boolean
+    end
+  end
+
+  defmodule Factory do
+    use ExMachina.Ecto, repo: TestRepo
+
+    def factory(:settings, _attrs) do
+      %Settings{
+        email_signature: "Mr. John Doe",
+        send_emails: true
+      }
+    end
+
+    def factory(:user, _attrs) do
+      %User{
+        name: "John Doe",
+        admin: false,
+        settings: build(:settings)
+      }
+    end
+  end
+
+  test "create/1 saves `embeds_one` record defined in the factory" do
+    Factory.create(:user)
+
+    user = TestRepo.one(User)
+    assert %{settings: %{email_signature: "Mr. John Doe", send_emails: true}} = user
+  end
+
+  test "create/2 saves `embeds_one` record when overridden" do
+    settings = %Settings{email_signature: "Mrs. Jane Doe"}
+    Factory.create(:user, settings: settings)
+
+    user = TestRepo.one(User)
+    assert user.settings.email_signature == settings.email_signature
+  end
+end


### PR DESCRIPTION
This covers behavior added in 080498ee4c3a5a70b69f478c7877d2979e879e01

Also updated mix.exs so that a migration could be generated during development without prefixing with MIX_ENV=test.