### PR TITLE
Add info about preloading factories to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ By default Phoenix imports `Ecto.Model` in the generated `ConnCase` and
 import Ecto.Model, except: [build: 2]
 ```
 
+If you want to keep the factories somewhere other than test/support,
+change this line in mix.exs:
+
+```elixir
+# Add the folder to the end of the list. In this case we're
+# adding `test/factories`.
+defp elixirc_paths(:test), do: [
+  "lib", "web", "test/support", "test/factories"
+]
+```
+
 ## Usage in a test
 
 ```elixir


### PR DESCRIPTION
I wanted to keep all my factories in `test/factories` folder, which is not loaded by default in the Phoenix framework. I think this information might be useful in the readme.