### PR TITLE
use always correct association_id key name (as defined on schema)

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -172,9 +172,12 @@ defmodule ExMachina.Ecto do
     end
   end
 
-  defp put_assoc(record, association_name, association) do
-    association_id = "#{association_name}_id" |> String.to_atom
+  defp get_owner_key(record, association_name) do
+    record.__struct__.__schema__(:association, association_name).owner_key
+  end
 
+  defp put_assoc(record, association_name, association) do
+    association_id = get_owner_key(record, association_name)
     record
     |> Map.put(association_id, association.id)
     |> Map.put(association_name, association)

--- a/priv/test_repo/migrations/20151111000420_create_company_account.exs
+++ b/priv/test_repo/migrations/20151111000420_create_company_account.exs
@@ -1,0 +1,10 @@
+defmodule ExMachina.TestRepo.Migrations.CreateCompanyAccount do
+  use Ecto.Migration
+
+  def change do
+    create table(:company_accounts) do
+      add :name, :string
+      add :manager_id, :integer
+    end
+  end
+end

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -10,6 +10,14 @@ defmodule ExMachina.EctoTest do
     end
   end
 
+  defmodule CompanyAccount do
+    use Ecto.Model
+    schema "company_accounts" do
+      field :name, :string
+      belongs_to :user, User, foreign_key: :manager_id
+    end
+  end
+
   defmodule Article do
     use Ecto.Model
     schema "articles" do
@@ -59,6 +67,13 @@ defmodule ExMachina.EctoTest do
         user: assoc(attrs, :user)
       }
     end
+
+    def factory(:company_account, atts) do
+      %CompanyAccount{
+        name: "BigBizAccount",
+        user: build(:user)
+      }
+    end
   end
 
   test "raises helpful error message if no repo is provided" do
@@ -81,6 +96,11 @@ defmodule ExMachina.EctoTest do
       name: "John Doe",
       admin: false
     }
+  end
+
+  test "save_record/1 works with irregular foreign_keys for belongs_to associations" do
+    company_account = Factory.create(:company_account)
+    assert company_account.user.name == "John Doe"
   end
 
   test "fields_for/2 raises when passed a map" do


### PR DESCRIPTION
Problem: 
- current implementation works based on convention, that association names always follow the pattern "#{association_name}_id". This is not always the case


Solution: 
- use the information on schema for that association to get the owner key