### PR TITLE
Fix test data to match with the test description

### DIFF
--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -60,7 +60,7 @@ defmodule ExMachinaTest do
   end
 
   test "build/2 merges passed in options as a map" do
-    assert Factory.build(:user, admin: true) == %{
+    assert Factory.build(:user, %{admin: true}) == %{
       id: 3,
       name: "John Doe",
       admin: true


### PR DESCRIPTION
This test says its supposed to merge a map, but it was a keyword list.