### PR TITLE
Drop `nil` values in `fields_for/2`

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -56,6 +56,7 @@ defmodule ExMachina.Ecto do
   def fields_for(module, factory_name, attrs \\ %{}) do
     module.build(factory_name, attrs)
     |> drop_ecto_fields
+    |> drop_nil_fields
   end
 
   defp drop_ecto_fields(record = %{__struct__: struct, __meta__: %{__struct__: Ecto.Schema.Metadata}}) do
@@ -66,6 +67,12 @@ defmodule ExMachina.Ecto do
   end
   defp drop_ecto_fields(record) do
     raise ArgumentError, "#{inspect record} is not an Ecto model. Use `build` instead."
+  end
+
+  defp drop_nil_fields(fields) do
+    fields
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Enum.into(%{})
   end
 
   @doc """

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -92,7 +92,6 @@ defmodule ExMachina.EctoTest do
 
   test "fields_for/2 removes Ecto specific fields" do
     assert Factory.fields_for(:user) == %{
-      id: nil,
       name: "John Doe",
       admin: false
     }

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -24,6 +24,10 @@ defmodule ExMachina.EctoTest do
       field :title, :string
       belongs_to :author, User
     end
+
+    def changeset(model, params \\ :emtpy) do
+      model |> cast(params, ~w(title author_id), [])
+    end
   end
 
   defmodule Comment do
@@ -90,11 +94,24 @@ defmodule ExMachina.EctoTest do
     end
   end
 
-  test "fields_for/2 removes Ecto specific fields" do
+  test "fields_for/2 removes Ecto specific fields and nil values" do
     assert Factory.fields_for(:user) == %{
       name: "John Doe",
       admin: false
     }
+  end
+
+  test "fields_for/2 works nice with changesets" do
+    author = Factory.create(:user)
+    article = Factory.build(:article, author: author)
+    changeset = Article.changeset(article, Factory.fields_for(:article))
+
+    refute changeset.valid?
+    assert changeset.errors[:author_id] == "can't be blank"
+
+    params = Factory.fields_for(:article, author_id: author.id)
+    changeset = Article.changeset(article, params)
+    assert changeset.valid?
   end
 
   test "save_record/1 works with irregular foreign_keys for belongs_to associations" do


### PR DESCRIPTION
When using `fields_for/2` while testing controllers or changesets, you end up having to manually remove unwanted keys  to satisfy your tests. This ensures that keys with `nil` values are removed.