### PR TITLE
Improve mix description

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule ExMachina.Mixfile do
       app: :ex_machina,
       version: @version,
       elixir: "~> 1.0",
-      description: "Easily create test data for Elixir applications",
+      description: "A factory library by the creators of FactoryGirl",
       source_url: @project_url,
       homepage_url: @project_url,
       elixirc_paths: elixirc_paths(Mix.env),


### PR DESCRIPTION
ExMachina currently doesn't show up on hex.pm if you search for "factory" or
"factories". I'd like to at least appear on that list. There are some
other libraries that do show up and mention that they are clones of
FactoryGirl. That seems to be something people are interested in, so it
may be worth saying that this is from the same people who created
FactoryGirl.