### PR TITLE
Actually display error message

### DIFF
--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -13,7 +13,27 @@ defmodule ExMachina do
     defexception [:message]
 
     def exception(factory_name) do
-      message = "No factory defined for #{inspect factory_name}"
+      message =
+        """
+        No factory defined for #{inspect factory_name}. This may be because you
+        defined a factory with two parameters like this:
+
+            def factory(:my_factory, attrs)
+
+        As of ExMachina 0.5.0, we no longer call factory/2. Please define your
+        factory function like this:
+
+            def factory(#{inspect factory_name}) do
+              ...
+            end
+
+        The assoc/3 function has also been removed. belongs_to relationships
+        can now be used with build:
+
+            def factory(#{inspect factory_name}) do
+              parent: build(:parent)
+            end
+        """
       %UndefinedFactory{message: message}
     end
   end
@@ -207,21 +227,6 @@ defmodule ExMachina do
       """
       def factory(factory_name) do
         raise UndefinedFactory, factory_name
-      end
-
-      def factory(factory_name, _) do
-        raise """
-        Use of factory/2 has been removed. Please use factory/1 instead.
-        belongs_to associations can be defined with build.
-
-          def factory(#{factory_name}) do
-            %{
-              ...
-              some_assoc: build(:some_assoc)
-              ...
-            }
-          end
-        """
       end
 
       @doc """

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -38,7 +38,7 @@ defmodule ExMachinaTest do
   end
 
   test "raises a helpful error if the factory is not defined" do
-    assert_raise ExMachina.UndefinedFactory, "No factory defined for :foo", fn ->
+    assert_raise ExMachina.UndefinedFactory, fn ->
       Factory.build(:foo)
     end
   end


### PR DESCRIPTION
Previously, the error message defined in `factory/2` would not be used
because internally we were only calling `factory/1`. This improves the
error message and moves it to the appropriate spot.

Addresses: https://github.com/thoughtbot/ex_machina/issues/63