### PR TITLE
Upgrade ecto

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -90,7 +90,7 @@ defmodule ExMachina.Ecto do
 
   defp not_loaded_assocs(model) do
     for {a, %{__struct__: Ecto.Association.Has}} <- get_assocs(model),
-      !Ecto.Association.loaded?(Map.get(model, a)),
+      !Ecto.assoc_loaded?(Map.get(model, a)),
       do: a
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ExMachina.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/thoughtbot/ex_machina"
-  @version "0.5.0"
+  @version "0.6.0"
 
   def project do
     [
@@ -36,7 +36,7 @@ defmodule ExMachina.Mixfile do
     [
       {:ex_doc, "~> 0.9", only: :dev},
       {:earmark, ">= 0.0.0", only: :dev},
-      {:ecto, "~> 1.0", only: [:dev, :test]},
+      {:ecto, "~> 1.1", only: [:dev, :test]},
       {:sqlite_ecto, "~> 1.0.0", only: :test}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"decimal": {:hex, :decimal, "1.1.0"},
   "earmark": {:hex, :earmark, "0.1.17"},
-  "ecto": {:hex, :ecto, "1.0.3"},
+  "ecto": {:hex, :ecto, "1.1.0"},
   "esqlite": {:hex, :esqlite, "0.2.1"},
   "ex_doc": {:hex, :ex_doc, "0.9.0"},
   "pipe": {:hex, :pipe, "0.0.2"},


### PR DESCRIPTION
Using the internal function Ecto.Association.loaded? no longer works. Fortunately there's a public function for the same thing Ecto.assoc_loaded? now

This makes #70 work (but with deprecation warnings still).