### PR TITLE
Use put_assoc/4 and put_embed/4 when building records

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -93,7 +93,7 @@ defmodule ExMachina.Ecto do
 
     Enum.reduce(keys, changeset, fn(key, changes) ->
       case Map.get(record, key) do
-        %Ecto.Association.NotLoaded{} ->
+        %{__struct__: Ecto.Association.NotLoaded} ->
           changes
         association ->
           Ecto.Changeset.put_assoc(changes, key, association)

--- a/test/ex_machina/ecto_has_many_test.exs
+++ b/test/ex_machina/ecto_has_many_test.exs
@@ -95,4 +95,9 @@ defmodule ExMachina.EctoHasManyTest do
     assert invoice.package_id == saved_package.id
     assert length(invoice.package.statuses) == 3
   end
+
+  test "create/1 saves when a has many association is not loaded" do
+    package = Factory.create(:package, invoices: %Ecto.Association.NotLoaded{})
+    assert package
+  end
 end

--- a/test/ex_machina/ecto_has_many_test.exs
+++ b/test/ex_machina/ecto_has_many_test.exs
@@ -7,6 +7,7 @@ defmodule ExMachina.EctoHasManyTest do
     schema "packages" do
       field :description, :string
       has_many :statuses, ExMachina.EctoHasManyTest.PackageStatus
+      has_many :invoices, ExMachina.EctoHasManyTest.Invoice
     end
   end
 


### PR DESCRIPTION
This breaks apart the general use of `Ecto.Changeset.change` when building records. Instead, it uses `put_assoc` and `put_embed`, eliminating the deprecation warnings in Ecto 1.1.