### PR TITLE
Allow to use custom changeset

### DIFF
--- a/priv/test_repo/migrations/20151002190029_create_users.exs
+++ b/priv/test_repo/migrations/20151002190029_create_users.exs
@@ -5,6 +5,7 @@ defmodule ExMachina.TestRepo.Migrations.CreateUsers do
     create table(:users) do
       add :name, :string
       add :admin, :boolean
+      add :token, :string
     end
   end
 end

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -7,6 +7,21 @@ defmodule ExMachina.EctoTest do
     schema "users" do
       field :name, :string
       field :admin, :boolean
+      field :token, :string
+    end
+
+    def changeset(model, params \\ :empty) do
+      model
+      |> cast(params, ~w(name), [])
+      |> generate_token
+    end
+
+    defp generate_token(changeset) do
+      put_change(changeset, :token, generated_token)
+    end
+
+    def generated_token do
+      "generated_token"
     end
   end
 
@@ -74,6 +89,10 @@ defmodule ExMachina.EctoTest do
         user: build(:user)
       }
     end
+
+    def make_changeset(%User{} = user, changes) do
+      User.changeset(user, changes)
+    end
   end
 
   test "raises helpful error message if no repo is provided" do
@@ -94,7 +113,8 @@ defmodule ExMachina.EctoTest do
     assert Factory.fields_for(:user) == %{
       id: nil,
       name: "John Doe",
-      admin: false
+      admin: false,
+      token: nil
     }
   end
 
@@ -114,6 +134,12 @@ defmodule ExMachina.EctoTest do
 
     new_user = TestRepo.one!(User)
     assert model == new_user
+  end
+
+  test "save_record/1 uses correct make_changeset" do
+    model = Factory.create(:user)
+
+    assert model.token == User.generated_token
   end
 
   test "save_record/1 saves associated records and sets the association and association id" do


### PR DESCRIPTION
Hi,
I think that changeset is quite an important part of ecto model creation,
but I could not find a way to use them with factories, so I changed the `save_record`
function to be able to use a custom changeset function.
With this change, the user can provide a `make_changeset/2` function in the factory to create
the changeset using the one defined in the model, or anywhere else.
As for `factory/1`, pattern matching can be used to choose the `make_changeset` function.
If nothing matches (e.g. `make_changeset/2` is not defined), we fallback to `Ecto.Changeset.change`.

Here is an example

```elixir
  defmodule Factory do
    use ExMachina.Ecto, repo: TestRepo

    def factory(:user) do
      %User{
        name: "John Doe",
        admin: false
      }
    end

    def factory(:article) do
      %Article{
        title: "My Awesome Article",
        author: build(:user)
      }
    end

    def make_changeset(%User{} = user, changes) do
      User.changeset(user, changes)
    end
  end

```