### PR TITLE
Fix nested has many

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In `mix.exs`, add the ExMachina dependency:
 
 ```elixir
 def deps do
-  [{:ex_machina, "~> 0.5"}]
+  [{:ex_machina, "~> 0.7"}]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ExMachina.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/thoughtbot/ex_machina"
-  @version "0.6.0"
+  @version "0.7.0"
 
   def project do
     [

--- a/priv/test_repo/migrations/20151222214939_create_shipments.exs
+++ b/priv/test_repo/migrations/20151222214939_create_shipments.exs
@@ -1,0 +1,13 @@
+defmodule ExMachina.TestRepo.Migrations.CreateShipments do
+  use Ecto.Migration
+
+  def change do
+    create table(:shipments) do
+      add :name, :string
+    end
+
+    alter table(:packages) do
+      add :shipment_id, :integer
+    end
+  end
+end

--- a/test/ex_machina/ecto_has_many_test.exs
+++ b/test/ex_machina/ecto_has_many_test.exs
@@ -84,14 +84,6 @@ defmodule ExMachina.EctoHasManyTest do
     end
   end
 
-  test "create/1 saves nested `has_many` records" do
-    shipment = Factory.create(:shipment)
-
-    assert length(shipment.packages) == 2
-    statuses = shipment.packages |> Enum.flat_map(&Map.get(&1, :statuses))
-    assert length(statuses) == 6
-  end
-
   test "create/1 saves `has_many` records defined in the factory" do
     package = Factory.create(:package)
 
@@ -127,5 +119,22 @@ defmodule ExMachina.EctoHasManyTest do
   test "create/1 saves when a has many association is not loaded" do
     package = Factory.create(:package, invoices: %Ecto.Association.NotLoaded{})
     assert package
+  end
+
+  test "create/1 saves nested `has_many` records" do
+    shipment = Factory.create(:shipment)
+
+    assert length(shipment.packages) == 2
+    statuses = shipment.packages |> Enum.flat_map(&Map.get(&1, :statuses))
+    assert length(statuses) == 6
+  end
+
+  test "create/2 saves nested `belongs_to` records" do
+    shipment = Factory.build(:shipment)
+    package  = Factory.build(:package, shipment: shipment)
+    status   = Factory.build(:package_status, package: package) |> Factory.create
+
+    assert %{ package: %{ shipment: s } } = status
+    refute is_nil s
   end
 end

--- a/test/ex_machina/ecto_has_many_test.exs
+++ b/test/ex_machina/ecto_has_many_test.exs
@@ -2,12 +2,22 @@ defmodule ExMachina.EctoHasManyTest do
   use ExMachina.EctoCase
   alias ExMachina.TestRepo
 
+  defmodule Shipment do
+    use Ecto.Model
+    schema "shipments" do
+      field :name, :string
+      has_many :packages, ExMachina.EctoHasManyTest.Package
+    end
+  end
+
   defmodule Package do
     use Ecto.Model
     schema "packages" do
       field :description, :string
       has_many :statuses, ExMachina.EctoHasManyTest.PackageStatus
       has_many :invoices, ExMachina.EctoHasManyTest.Invoice
+
+      belongs_to :shipment, Shipment
     end
   end
 
@@ -62,6 +72,24 @@ defmodule ExMachina.EctoHasManyTest do
         package: build(:shipped_package)
       }
     end
+
+    def factory(:shipment) do
+      %Shipment{
+        name: "I'm nested",
+        packages: [
+          build(:shipped_package),
+          build(:shipped_package)
+        ]
+      }
+    end
+  end
+
+  test "create/1 saves nested `has_many` records" do
+    shipment = Factory.create(:shipment)
+
+    assert length(shipment.packages) == 2
+    statuses = shipment.packages |> Enum.flat_map(&Map.get(&1, :statuses))
+    assert length(statuses) == 6
   end
 
   test "create/1 saves `has_many` records defined in the factory" do


### PR DESCRIPTION
(I have rebased this branch against the PR that bumps the version to 0.7.0)

In the current state of affairs, if we were to have factories building
nested `has_many` relationships the built models cannot be saved. When
`creating` a model with such a factory (like the shipment factory in
`ecto_has_many_test.exs`) a user would see the following error:

(see the changes in 0573f23 for the model & factory definitions)

```
** (ArgumentError) model ExMachina.EctoHasManyTest.Package has value `[%ExMachina.EctoHasManyTest.PackageStatus{__meta__: #Ecto.Schema.Metadata<:built>, id: nil, package: #Ecto.Association.NotLoaded<association :package is not loaded>, package_id: nil, status: "ordered"}, %ExMachina.EctoHasManyTest.PackageStatus{__meta__: #Ecto.Schema.Metadata<:built>, id: nil, package: #Ecto.Association.NotLoaded<association :package is not loaded>, package_id: nil, status: "sent"}, %ExMachina.EctoHasManyTest.PackageStatus{__meta__: #Ecto.Schema.Metadata<:built>, id: nil, package: #Ecto.Association.NotLoaded<association :package is not loaded>, package_id: nil, status: "shipped"}]` set for assoc named `statuses`. Assocs can only be manipulated via changesets, be it on insert, update or delete.
```

This PR fixes this issue by calling `put_assoc_changes` recursively in nested `has_many` relations.

(I would like to add more tests stressing more complex relationships if I get some more time before the review. I will probably send some commits in the next couple of days)