### PR TITLE
Rename fields_for to params_for

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ create(:comment, attrs)
 create_pair(:comment, attrs)
 create_list(3, :comment, attrs)
 
-# `fields_for` returns a plain map without any Ecto specific attributes.
+# `params_for` returns a plain map without any Ecto specific attributes.
 # This is only available when using `ExMachina.Ecto`.
-fields_for(:comment, attrs)
+params_for(:comment, attrs)
 ```
 
 ## Usage in a test

--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -7,8 +7,12 @@ defmodule ExMachina.Ecto do
 
         @repo unquote(repo)
 
+        def params_for(factory_name, attrs \\ %{}) do
+          ExMachina.Ecto.params_for(__MODULE__, factory_name, attrs)
+        end
+
         def fields_for(factory_name, attrs \\ %{}) do
-          ExMachina.Ecto.fields_for(__MODULE__, factory_name, attrs)
+          raise "fields_for/2 has been renamed to params_for/2."
         end
 
         def save_record(record) do
@@ -61,9 +65,9 @@ defmodule ExMachina.Ecto do
       end
 
       # Returns %{name: "John Doe", admin: true}
-      fields_for(:user, admin: true)
+      params_for(:user, admin: true)
   """
-  def fields_for(module, factory_name, attrs \\ %{}) do
+  def params_for(module, factory_name, attrs \\ %{}) do
     module.build(factory_name, attrs)
     |> drop_ecto_fields
   end

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -75,17 +75,17 @@ defmodule ExMachina.EctoTest do
     end
   end
 
-  test "fields_for/2 removes Ecto specific fields" do
-    assert Factory.fields_for(:user) == %{
+  test "params_for/2 removes Ecto specific fields" do
+    assert Factory.params_for(:user) == %{
       id: nil,
       name: "John Doe",
       admin: false
     }
   end
 
-  test "fields_for/2 raises when passed a map" do
+  test "params_for/2 raises when passed a map" do
     assert_raise ArgumentError, fn ->
-      Factory.fields_for(:user_map)
+      Factory.params_for(:user_map)
     end
   end
 


### PR DESCRIPTION
This reads much more nicely IMO

```elixir
post comment_path(conn, :create), params_for(:comment)

assert Comment.changeset(%Comment{}, params_for(:comment)).valid?
```
