### PR TITLE
Use new factory definition syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ defmodule MyApp.Factory do
   # without Ecto
   use ExMachina
 
-  def factory(:user) do
+  def user_factory do
     %User{
       name: "Jane Smith",
       email: sequence(:email, &"email-#{&1}@example.com"),
     }
   end
 
-  def factory(:article) do
+  def article_factory do
     %Article{
       title: "Use ExMachina!",
       # associations are inserted when you call `create`
@@ -99,7 +99,7 @@ defmodule MyApp.Factory do
     }
   end
 
-  def factory(:comment) do
+  def comment_factory do
     %Comment{
       text: "It's great!",
       article: build(:article),
@@ -179,7 +179,7 @@ and embeds. Since we automatically save these records for you, we advise that
 factory definitions only use `build/2` when declaring associations, like so:
 
 ```elixir
-def factory(:article) do
+def article_factory do
   %Article{
     title: "Use ExMachina!",
     # associations are inserted when you call `create`
@@ -240,7 +240,7 @@ defmodule MyApp.Factory do
   # Using this will add json_encode/2, json_encode_pair/2 and json_encode_list/2
   use MyApp.JsonEncodeStrategy
 
-  def factory(:user) do
+  def user_factory do
     %User{name: "John"}
   end
 end

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -19,7 +19,7 @@ defmodule ExMachina do
 
         Please check for typos or define your factory:
 
-            def factory(#{inspect factory_name}) do
+            def #{inspect factory_name}_factory do
               ...
             end
         """
@@ -58,7 +58,7 @@ defmodule ExMachina do
 
   ## Examples
 
-      def factory(:comment) do
+      def comment_factory do
         %{
           # Will generate "Comment Title 0" then "Comment Title 1", etc.
           title: sequence("Comment Title")
@@ -72,7 +72,7 @@ defmodule ExMachina do
 
   ## Examples
 
-      def factory(:user) do
+      def user_factory do
         %{
           # Will generate "me-0@example.com" then "me-1@example.com", etc.
           email: sequence(:email, &"me-\#{&1}@foo.com")
@@ -86,7 +86,7 @@ defmodule ExMachina do
 
   ## Example
 
-      def factory(:user) do
+      def user_factory do
         %{name: "John Doe", admin: false}
       end
 
@@ -95,7 +95,12 @@ defmodule ExMachina do
   """
   def build(module, factory_name, attrs \\ %{}) do
     attrs = Enum.into(attrs, %{})
-    module.factory(factory_name) |> do_merge(attrs)
+    function_name = Atom.to_string(factory_name) <> "_factory" |> String.to_atom
+    if Code.ensure_loaded?(module) && function_exported?(module, function_name, 0) do
+      apply(module, function_name, []) |> do_merge(attrs)
+    else
+      raise UndefinedFactoryError, factory_name
+    end
   end
 
   defp do_merge(%{__struct__: _} = record, attrs) do

--- a/lib/ex_machina/strategy.ex
+++ b/lib/ex_machina/strategy.ex
@@ -20,7 +20,7 @@ defmodule ExMachina.Strategy do
         use ExMachina
         use MyApp.JsonEncodeStrategy
 
-        def factory(:user) do
+        def user_factory do
           %User{name: "John"}
         end
       end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ExMachina.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/thoughtbot/ex_machina"
-  @version "1.0.0-beta.0"
+  @version "1.0.0-beta.1"
 
   def project do
     [

--- a/test/ex_machina/ecto_strategy_test.exs
+++ b/test/ex_machina/ecto_strategy_test.exs
@@ -22,14 +22,14 @@ defmodule ExMachina.EctoStrategyTest do
     use ExMachina
     use ExMachina.EctoStrategy, repo: TestRepo
 
-    def factory(:user) do
+    def user_factory do
       %User{
         name: "John Doe",
         admin: false
       }
     end
 
-    def factory(:article) do
+    def article_factory do
       %Article{
         title: "My Awesome Article",
         author: build(:user)
@@ -40,7 +40,7 @@ defmodule ExMachina.EctoStrategyTest do
   defmodule FactoryWithNoRepo do
     use ExMachina.EctoStrategy
 
-    def factory(:whatever) do
+    def whatever_factory do
       %{}
     end
   end

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -13,14 +13,14 @@ defmodule ExMachina.EctoTest do
   defmodule Factory do
     use ExMachina.Ecto, repo: TestRepo
 
-    def factory(:user) do
+    def user_factory do
       %User{
         name: "John Doe",
         admin: false
       }
     end
 
-    def factory(:user_map) do
+    def user_map_factory do
       %{
         id: 3,
         name: "John Doe",

--- a/test/ex_machina/strategy_test.exs
+++ b/test/ex_machina/strategy_test.exs
@@ -13,7 +13,7 @@ defmodule ExMachina.StrategyTest do
     use ExMachina
     use FakeJsonStrategy, foo: :bar
 
-    def factory(:user) do
+    def user_factory do
       %{
         name: "John"
       }

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -4,7 +4,7 @@ defmodule ExMachinaTest do
   defmodule Factory do
     use ExMachina
 
-    def factory(:user) do
+    def user_factory do
       %{
         id: 3,
         name: "John Doe",
@@ -12,19 +12,19 @@ defmodule ExMachinaTest do
       }
     end
 
-    def factory(:email) do
+    def email_factory do
       %{
         email: sequence(:email, &"me-#{&1}@foo.com")
       }
     end
 
-    def factory(:article) do
+    def article_factory do
       %{
         title: sequence("Post Title")
       }
     end
 
-    def factory(:struct) do
+    def struct_factory do
       %{
         __struct__: Foo.Bar
       }


### PR DESCRIPTION
Pros

* Can use symbol view/ctags to jump to the factories more easily
* Can add helper functions underneath the factory they belong to
* IMO it's easier to scan your factory module for a particular factory
* Easier to type :)
* If/when callbacks are introduced, this will allow you to put the
  callback functions near the factory

Cons

* A little more *magic* since you still call the functions with atoms,
  e.g.`build(:user)`

Closes #101 