### PR TITLE
Omit trailing space from sequence shortcut

### DIFF
--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -52,16 +52,22 @@ defmodule ExMachina do
   end
 
   @doc """
-  Shortcut for creating unique values. Similar to sequence/2
+  Shortcut for creating unique string values. Similar to sequence/2
 
   For more customization of the generated string, see ExMachina.sequence/2
 
   ## Examples
 
-      def comment_factory do
-        %{
-          # Will generate "Comment Title 0" then "Comment Title 1", etc.
-          title: sequence("Comment Title")
+      def user_factory do
+        %User{
+          # Will generate "username0" then "username1", etc.
+          username: sequence("username")
+        }
+      end
+
+      def article_factory do
+        %Article{
+          title: sequence("Article Title")
         }
       end
   """

--- a/lib/ex_machina/sequence.ex
+++ b/lib/ex_machina/sequence.ex
@@ -5,7 +5,7 @@ defmodule ExMachina.Sequence do
 
   def next(sequence_name) when is_binary(sequence_name) do
     next sequence_name, fn(n)->
-      sequence_name <> " " <> to_string(n)
+      sequence_name <> to_string(n)
     end
   end
 

--- a/test/ex_machina/sequence_test.exs
+++ b/test/ex_machina/sequence_test.exs
@@ -20,8 +20,8 @@ defmodule ExMachina.SequenceTest do
   end
 
   test "let's you quickly create sequences" do
-    assert "Comment Body 0" == Sequence.next("Comment Body")
-    assert "Comment Body 1" == Sequence.next("Comment Body")
+    assert "Comment Body0" == Sequence.next("Comment Body")
+    assert "Comment Body1" == Sequence.next("Comment Body")
   end
 
   test "only accepts strings for sequence shortcut" do

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -37,8 +37,8 @@ defmodule ExMachinaTest do
   end
 
   test "sequence/1 shortcut for creating sequences" do
-    assert "Post Title 0" == Factory.build(:article).title
-    assert "Post Title 1" == Factory.build(:article).title
+    assert "Post Title0" == Factory.build(:article).title
+    assert "Post Title1" == Factory.build(:article).title
   end
 
   test "raises a helpful error if the factory is not defined" do


### PR DESCRIPTION
Closes #108

This makes it so the sequence short function can be used for things like
usernames where a space will make the username invalid.