### PR TITLE
Add name_from_struct for strategies

### DIFF
--- a/lib/ex_machina/ecto_strategy.ex
+++ b/lib/ex_machina/ecto_strategy.ex
@@ -3,11 +3,11 @@ defmodule ExMachina.EctoStrategy do
 
   use ExMachina.Strategy, function_name: :insert
 
-  def handle_insert(%{__meta__: %{__struct__: Ecto.Schema.Metadata}} = record, repo: repo) do
+  def handle_insert(%{__meta__: %{__struct__: Ecto.Schema.Metadata}} = record, %{repo: repo}) do
     repo.insert! record
   end
 
-  def handle_insert(record, repo: _repo) do
+  def handle_insert(record, %{repo: _repo}) do
     raise ArgumentError, "#{inspect record} is not an Ecto model. Use `build` instead"
   end
 

--- a/lib/ex_machina/strategy.ex
+++ b/lib/ex_machina/strategy.ex
@@ -28,7 +28,20 @@ defmodule ExMachina.Strategy do
       # Will build and then return a JSON encoded version of the user.
       MyApp.JsonFactories.json_encode(:user)
 
-  See `ExMachina.EctoStrategy` in the ExMachina repo to see another example.
+  The arguments sent to the handling function are
+
+    1) The built record
+    2) The options passed to the strategy
+
+  The options sent as the second argument are always converted to a map. The
+  options are anything you passed when you `use` your strategy in your factory,
+  merged together with `%{factory_module: FactoryItWasCalledFrom}`.
+
+  This allows for customizing the strategy, and for calling other functions on
+  the factory if needed.
+
+  See `ExMachina.EctoStrategy` in the ExMachina repo, and the docs for
+  `name_from_struct/1` for more examples.
   """
 
   @doc false
@@ -46,9 +59,11 @@ defmodule ExMachina.Strategy do
 
         quote do
           def unquote(function_name)(already_built_record) when is_map(already_built_record) do
+            opts = Map.new(unquote(opts)) |> Map.merge(%{factory_module: __MODULE__})
+
             apply unquote(custom_strategy_module),
               unquote(handle_response_function_name),
-              [already_built_record, unquote(opts)]
+              [already_built_record, opts]
           end
 
           def unquote(function_name)(factory_name, attrs \\ %{}) do
@@ -77,5 +92,57 @@ defmodule ExMachina.Strategy do
 
     Example: use ExMachina.Strategy, function_name: :json_encode
     """
+  end
+
+  @doc ~S"""
+  Returns the factory name from a struct. Useful for strategies with callbacks.
+
+  This function can be useful when you want to call other functions based on the
+  type of struct passed in. For example, if you wanted to call a function on the
+  factory module before JSON encoding.
+
+  ## Examples
+
+      ExMachina.Strategy.name_from_struct(%User{}) # Returns :user
+      ExMachina.Strategy.name_from_struct(%MyUser{}) # Returns :my_user
+      ExMachina.Strategy.name_from_struct(%MyApp.MyTask{}) # Returns :my_task
+
+  ## Implementing callback functions with name_from_struct/1
+
+      defmodule MyApp.JsonEncodeStrategy do
+        use ExMachina.Strategy, function_name: :json_encode
+
+        def handle_json_encode(record, %{factory_module: factory_module}) do
+          # If the record was a %User{} this would return :before_encode_user
+          callback_func_name = :"before_encode_#{ExMachina.Strategy.name_from_struct(record)}"
+
+          if callback_defined?(factory_module, callback_func_name) do
+            # First call the callback function
+            apply(factory_module, callback_func_name, [record])
+            # Then encode it
+            |> Poison.encode!
+          else
+            # Otherwise, encode it without calling any callback
+            Poison.encode!(record)
+          end
+        end
+
+        defp callback_defined?(module, func_name) do
+          Code.ensure_loaded?(module) && function_exported?(module, func_name, 1)
+        end
+      end
+  """
+  def name_from_struct(%{__struct__: struct_name}) do
+    struct_name
+    |> Module.split
+    |> List.last
+    |> underscore
+    |> String.downcase
+    |> String.to_atom
+  end
+
+  defp underscore(name) do
+    Regex.split(~r/(?=[A-Z])/, name)
+    |> Enum.join("_")
   end
 end

--- a/test/ex_machina/strategy_test.exs
+++ b/test/ex_machina/strategy_test.exs
@@ -20,8 +20,14 @@ defmodule ExMachina.StrategyTest do
     end
   end
 
+  test "name_from_struct returns the factory name based on passed in struct" do
+    assert ExMachina.Strategy.name_from_struct(%{__struct__: User}) == :user
+    assert ExMachina.Strategy.name_from_struct(%{__struct__: TwoWord}) == :two_word
+    assert ExMachina.Strategy.name_from_struct(%{__struct__: NameSpace.TwoWord}) == :two_word
+  end
+
   test "defines functions based on the strategy name" do
-    strategy_options = [foo: :bar]
+    strategy_options = %{foo: :bar, factory_module: Factory}
 
     Factory.build(:user) |> Factory.json_encode
     built_user = Factory.build(:user)


### PR DESCRIPTION
Options passed to handling functions are now a map which makes it easier
to pattern match. It also includes the calling factory module in the
options.

name_from_struct/1 is added so that people can create strategies that
define callbacks or need to call other functions with the factory name.

Closes #111. See discussion for more details on why this strategy was
chosen.