### PR TITLE
Update README to include installing from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In `mix.exs`, add the ExMachina dependency:
 
 ```elixir
 def deps do
-  # Latest from hex.pm
+  # Get the latest from hex.pm. Works with Ecto 1.1, but not Ecto 2.0
   [{:ex_machina, "~> 0.6.1"}]
   
   # Or use ExMachina beta. This version only works with Ecto 2.0

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ In `mix.exs`, add the ExMachina dependency:
 
 ```elixir
 def deps do
+  # Latest from hex.pm
   [{:ex_machina, "~> 0.6.1"}]
+  
+  # Or use ExMachina beta. This version only works with Ecto 2.0
+  [{:ex_machina, "~> 1.0.0-beta.1", github: "thoughtbot/ex_machina"}]
 end
 ```
 


### PR DESCRIPTION
I think this is important since a lot of people are moving to Ecto 2.0 lately. I'm hoping to release ExMachina 1.0 when Ecto 2.0 ships