### PR TITLE
Don't return id field in params_for

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -50,11 +50,11 @@ defmodule ExMachina.Ecto do
   This is only for use with Ecto models.
 
   Will return a map with the fields and virtual fields, but without the Ecto
-  metadata and associations.
+  metadata, associations, and the primary key.
 
   ## Example
 
-      def factory(:user) do
+      def user_factory do
         %MyApp.User{name: "John Doe", admin: false}
       end
 
@@ -71,6 +71,7 @@ defmodule ExMachina.Ecto do
     |> Map.from_struct
     |> Map.delete(:__meta__)
     |> Map.drop(struct.__schema__(:associations))
+    |> Map.drop(struct.__schema__(:primary_key))
   end
   defp drop_ecto_fields(record) do
     raise ArgumentError, "#{inspect record} is not an Ecto model. Use `build` instead."

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -57,7 +57,6 @@ defmodule ExMachina.EctoTest do
 
   test "params_for/2 removes Ecto specific fields" do
     assert Factory.params_for(:user) == %{
-      id: nil,
       name: "John Doe",
       admin: false
     }


### PR DESCRIPTION
I can't think of any use case where you would want the id field when
using params_for. For something scenarios like submitting to an API, or
getting the bare fields to test validations it would be rare to
actually submit the id itself, and so the current behavior feels
unexpected.