### PR TITLE
Drop the database for each test run

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
+Mix.Task.run "ecto.drop", ["quiet", "-r", "ExMachina.TestRepo"]
 Mix.Task.run "ecto.create", ["quiet", "-r", "ExMachina.TestRepo"]
 Mix.Task.run "ecto.migrate", ["-r", "ExMachina.TestRepo"]
 


### PR DESCRIPTION
Now that we are using a single file for migrations, we should drop the
database each test run to get the new schema.