### PR TITLE
Fix #90 Insert Twice

### DIFF
--- a/lib/ex_machina/ecto_strategy.ex
+++ b/lib/ex_machina/ecto_strategy.ex
@@ -3,6 +3,15 @@ defmodule ExMachina.EctoStrategy do
 
   use ExMachina.Strategy, function_name: :insert
 
+  def handle_insert(%{__meta__: %{state: :loaded}} = record, _) do
+    raise "You called `insert` on a record that has already been inserted.
+     Make sure that you have not accidentally called insert twice.
+
+     The record you attempted to insert:
+
+     #{inspect record, limit: :infinity}"
+  end
+
   def handle_insert(%{__meta__: %{__struct__: Ecto.Schema.Metadata}} = record, %{repo: repo}) do
     repo.insert! record
   end

--- a/test/ex_machina/ecto_strategy_test.exs
+++ b/test/ex_machina/ecto_strategy_test.exs
@@ -46,4 +46,11 @@ defmodule ExMachina.EctoStrategyTest do
 
     assert article.author == my_user
   end
+
+  test "insert/1 raises if attempting to insert already inserted record" do
+    message = ~r/You called `insert` on a record that has already been inserted./
+    assert_raise RuntimeError, message, fn ->
+      TestFactory.insert(:user, name: "Maximus") |> TestFactory.insert
+    end
+  end
 end


### PR DESCRIPTION
Hey there, so I think this one is good to go.

Note, I split handle_insert function per @paulcsmith comment in #90 
```
  def handle_insert(%{__meta__: %{state: :loaded}} = record, _) do
    raise ArgumentError,
    "you called `insert` on #{inspect record} but it has already been saved.
     You can only call `insert` on records that haven't been inserted yet"
  end

  def handle_insert(%{__meta__: %{__struct__: Ecto.Schema.Metadata}} = record, %{repo: repo}) do
    repo.insert!(record)
  end
```

Note: I rebased with the latest test changes from @jsteiner regarding Factory -> TestFactory

Let me know if it needs anything else. Cheers!