### PR TITLE
Fix #106 - ExMachina.create functions error helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ExMachina makes it easy to create test data and associations. It works great
 with Ecto, but is configurable to work with any persistence library.
 
-> **This README follows master, which may not be the currently published version**. Here are the 
+> **This README follows master, which may not be the currently published version**. Here are the
 [docs for the latest published version of ExMachina](https://hexdocs.pm/ex_machina/README.html).
 
 ## Installation
@@ -18,7 +18,7 @@ In `mix.exs`, add the ExMachina dependency:
 def deps do
   # Get the latest from hex.pm. Works with Ecto 1.1, but not Ecto 2.0
   [{:ex_machina, "~> 0.6.1"}]
-  
+
   # Or use ExMachina beta. This version only works with Ecto 2.0
   [{:ex_machina, "~> 1.0.0-beta.1", github: "thoughtbot/ex_machina"}]
 end
@@ -249,7 +249,7 @@ end
 
 defmodule MyApp.Factory do
   use ExMachina
-  # Using this will add json_encode/2, json_encode_pair/2 and json_encode_list/2
+  # Using this will add json_encode/2, json_encode_pair/2 and json_encode_list/3
   use MyApp.JsonEncodeStrategy
 
   def user_factory do

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -49,6 +49,35 @@ defmodule ExMachina do
       def build_list(number_of_factories, factory_name, attrs \\ %{}) do
         ExMachina.build_list(__MODULE__, number_of_factories, factory_name, attrs)
       end
+
+      def create(_) do
+        raise_function_replaced_error("create/1", "insert/1")
+      end
+
+      def create(_, _) do
+        raise_function_replaced_error("create/2", "insert/2")
+      end
+
+      def create_pair(_, _) do
+        raise_function_replaced_error("create_pair/2", "insert_pair/2")
+      end
+
+      def create_list(_, _, _) do
+        raise_function_replaced_error("create_list/3", "insert_list/3")
+      end
+
+      defp raise_function_replaced_error(old_function, new_function) do
+        raise """
+        #{old_function} has been removed.
+
+        If you are using ExMachina.Ecto, use #{new_function} instead.
+
+        If you are using ExMachina with a custom `save_record/2`, you now must use ExMachina.Strategy.
+        See the ExMachina.Strategy documentation for examples.
+        """
+      end
+
+      defoverridable [create: 1, create: 2, create_pair: 2, create_list: 3]
     end
   end
 

--- a/lib/ex_machina/strategy.ex
+++ b/lib/ex_machina/strategy.ex
@@ -6,7 +6,7 @@ defmodule ExMachina.Strategy do
 
       defmodule MyApp.JsonEncodeStrategy do
         # The function_name will be used to generate functions in your factory
-        # This example adds json_encode/1, json_encode/2, json_encode_pair/2 and json_encode_list/2
+        # This example adds json_encode/1, json_encode/2, json_encode_pair/2 and json_encode_list/3
         use ExMachina.Strategy, function_name: :json_encode
 
         # Define a function for handling the records.

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -98,4 +98,22 @@ defmodule ExMachinaTest do
     }
     assert records == [expected_record, expected_record, expected_record]
   end
+
+  test "raises helpful error when using old create functions" do
+    assert_raise RuntimeError, ~r/create\/1 has been removed/, fn ->
+      Factory.create(:user)
+    end
+
+    assert_raise RuntimeError, ~r/create\/2 has been removed/, fn ->
+      Factory.create(:user, admin: true)
+    end
+
+    assert_raise RuntimeError, ~r/create_pair\/2 has been removed/, fn ->
+      Factory.create_pair(:user, admin: true)
+    end
+
+    assert_raise RuntimeError, ~r/create_list\/3 has been removed/, fn ->
+      Factory.create_list(3, :user, admin: true)
+    end
+  end
 end


### PR DESCRIPTION
Hey @paulcsmith:

**Codebase changes:**

1. [`create` functions with error-helpers](https://github.com/davidkuhta/ex_machina/blob/error-helpers/lib/ex_machina.ex#L53) 

**Tests:**
Split based on arity to match the pattern of existing tests:

1. [`create/2`, `create_pair/2`, `create_list/3` tests](https://github.com/davidkuhta/ex_machina/blob/error-helpers/test/ex_machina_test.exs#L102)
2. [`create/1` test](https://github.com/davidkuhta/ex_machina/blob/error-helpers/test/ex_machina/ecto_strategy_test.exs#L57)

**Other:**

1. Corrected two comments which had `_list/2` instead of `_list/3`

Cheers!