### PR TITLE
Add support for lazy attributes

### DIFF
--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -104,7 +104,7 @@ defmodule ExMachina do
     attrs = Enum.into(attrs, %{})
     function_name = Atom.to_string(factory_name) <> "_factory" |> String.to_atom
     if Code.ensure_loaded?(module) && function_exported?(module, function_name, 0) do
-      apply(module, function_name, []) |> do_merge(attrs)
+      apply(module, function_name, []) |> do_merge(attrs) |> resolve
     else
       raise UndefinedFactoryError, factory_name
     end
@@ -116,6 +116,24 @@ defmodule ExMachina do
   defp do_merge(record, attrs) do
     Map.merge(record, attrs)
   end
+
+  # Entry point to resolve the record map/struct
+  defp resolve(record), do: resolve(record, nil)
+
+  defp resolve(%{__struct__: _} = record, scope) do
+    attrs = Map.from_struct(record) |> resolve(scope)
+    struct!(record, attrs)
+  end
+  defp resolve(record, scope) when is_map(record) do
+    for {key, value} <- record, into: %{}, do: {key, resolve(value, scope || record)}
+  end
+  defp resolve(function, scope) when is_function(function) do
+    function.(scope)
+  end
+  defp resolve(list, scope) when is_list(list) do
+    Enum.map(list, &resolve(&1, scope))
+  end
+  defp resolve(value, _scope), do: value
 
   @doc """
   Builds and returns 2 records with the passed in factory_name and attrs

--- a/lib/ex_machina/deferred_attribute.ex
+++ b/lib/ex_machina/deferred_attribute.ex
@@ -1,0 +1,17 @@
+defmodule ExMachina.DeferredAttribute do
+  @moduledoc """
+  Defines a struct that enables deferred attributes in a factory.
+
+  Fields:
+
+  * `weight` - Defines the numeric in which deferred attributes are computed.
+    Lower values are computed before higher values.  Should be an Integer.
+    Defaults to 0.
+  * `func` - A function which computes the attribute value.  The function should
+    receive a single argument, which is the current state of the factory during
+    build at the point at which the function is "undeferred".  See
+    `ExMachina.defer/2`.
+  """
+
+  defstruct weight: 0, func: nil
+end

--- a/priv/test_repo/migrations/1_migrate_all.exs
+++ b/priv/test_repo/migrations/1_migrate_all.exs
@@ -2,15 +2,21 @@ defmodule ExMachina.TestRepo.Migrations.MigrateAll do
   use Ecto.Migration
 
   def change do
+    create table(:sites) do
+      add :name, :string
+    end
+
     create table(:users) do
       add :name, :string
       add :admin, :boolean
+      add :site_id, :integer
     end
 
     create table(:articles) do
       add :title, :string
       add :author_id, :integer
       add :editor_id, :integer
+      add :site_id, :integer
     end
   end
 end

--- a/test/ex_machina/ecto_strategy_test.exs
+++ b/test/ex_machina/ecto_strategy_test.exs
@@ -47,6 +47,18 @@ defmodule ExMachina.EctoStrategyTest do
     assert article.author == my_user
   end
 
+  test "lazy attributes can be used to assign associations to the same record" do
+    article = TestFactory.insert(:article_for_site)
+    assert article.author.site == article.site
+  end
+
+  test "lazy associations can be overriden by passed in attributes" do
+    site = TestFactory.insert(:site)
+    article = TestFactory.insert(:article_for_site, site: site)
+    assert article.site == site
+    assert article.author.site == site
+  end
+
   test "insert/1 raises if attempting to insert already inserted record" do
     message = ~r/You called `insert` on a record that has already been inserted./
     assert_raise RuntimeError, message, fn ->

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -33,7 +33,8 @@ defmodule ExMachina.EctoTest do
   test "params_for/2 removes Ecto specific fields" do
     assert TestFactory.params_for(:user) == %{
       name: "John Doe",
-      admin: false
+      admin: false,
+      site_id: nil
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -16,6 +16,20 @@ defmodule ExMachina.TestFactory do
     }
   end
 
+  def site_factory do
+    %ExMachina.Site{
+      name: "My Wonderful Blog"
+    }
+  end
+
+  def article_for_site_factory do
+    %ExMachina.Article{
+      site: insert(:site),
+      title: "My Awesome Article",
+      author: &build(:user, site: &1.site),
+    }
+  end
+
   def user_map_factory do
     %{
       id: 3,

--- a/test/support/models/article.ex
+++ b/test/support/models/article.ex
@@ -6,5 +6,6 @@ defmodule ExMachina.Article do
 
     belongs_to :author, ExMachina.User
     belongs_to :editor, ExMachina.User
+    belongs_to :site,   ExMachina.Site
   end
 end

--- a/test/support/models/sites.ex
+++ b/test/support/models/sites.ex
@@ -1,0 +1,7 @@
+defmodule ExMachina.Site do
+  use Ecto.Schema
+
+  schema "sites" do
+    field :name, :string
+  end
+end

--- a/test/support/models/user.ex
+++ b/test/support/models/user.ex
@@ -6,5 +6,6 @@ defmodule ExMachina.User do
     field :admin, :boolean
 
     has_many :articles, ExMachina.Article
+    belongs_to :site,   ExMachina.Site
   end
 end


### PR DESCRIPTION
You may defer calculation of your attributes, and even base one attribute upon another, by using functions:

``` elixir
def hero_factory do
  %{
    creature: "Bat",
    nickname: &"#{&1.creature}man",
    vehicle: &"#{&1.creature}mobile"
  }
end

build(:hero)
 # => %{creature: "Bat", nickname: "Batman", vehicle: "Batmobile"}
build(:hero, creature: "Spider", vehicle: "webs")
 # => %{creature: "Spider", nickname: "Spiderman", vehicle: "webs"}
```

This is especially helpful in complex object graphs where a record and its child both belong to the same parent.  This is common in multi-tenant apps, where many of the records belong to the same scope.  Consider a multi-site blog platform where Articles and Authors both belong to a Site, and Articles also belong to the User:

``` txt
Site <---- Author
  ^          ^
  |          |
  +------- Article
```

Such factories would be:

``` elixir
def site_factory do
  %Site{
    name: "Awesome Blog"
  }
end

def author_factory do
  %Author{
    name: "Danny Tanner",
    email: "danny@example.com",
    site: build(:site)
  }
end

def article_factory do
  %Article{
    title: "The House is Full",
    site: create(:site), # Unfortunately, site creation can't be deferred or Author won't see it
    author: build(:author, site: &(&1.site))
  }
end
```

Without lazy attributes, this could be accomplished through something like:

``` elixir
def article_factory do
  # Don't do this
  site = create(:site) # Site gets created despite the attributes you pass in build/insert :(
  %Article{
    site: site,
    title: "The House is Full",
    author: build(:author, site: site)
  }
end
```

But with lazy attributes, we can pass in the Site, keeping your inserts to a minimum:

``` elixir
def article_factory do
  %Article{
    site: create(:site),
    title: "The House is Full",
    author: build(:author, site: &(&1.site))
  }
end

article_for_auto_generated_site = build(:article)
 # => %Article{site: %Site{id: 1, ...}, author: %Author{site: %Site{id: 1, ...}, ...}}

specific_site = create(:site, name: "Special Blog")
article_for_specific_site = build(:article, site: specific_site)
 # => %Article{site: %Site{id: 2, ...}, author: %Author{site: %Site{id: 2, ...}, ...}}
```
