### PR TITLE
Fix compilation issue under OTP 19

### DIFF
--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -173,9 +173,7 @@ defmodule ExMachina do
   end
 
   defmacro __before_compile__(_env) do
-    # We are using line -1 because we don't want warnings coming from
-    # save_record/1 when someone defines there own save_record/1 function.
-    quote line: -1 do
+    quote do
       @doc """
       Raises a helpful error if no factory is defined.
       """


### PR DESCRIPTION
There is an issue with ExMachina when used with OTP 19

```
== Compilation error on file test/support/test_factory.ex ==
** (ArgumentError) argument error
    (stdlib) erl_anno.erl:318: :erl_anno.set(:file, 'nofile', -1)
    (stdlib) erl_parse.yrl:1516: anonymous fn/3 in :erl_parse.map_anno/2
    (stdlib) erl_parse.yrl:1631: :erl_parse.modify_anno1/3
    (stdlib) erl_parse.yrl:1517: :erl_parse.map_anno/2
    (stdlib) erl_lint.erl:703: :erl_lint."-set_file/2-lc$^0/1-0-"/2
    (stdlib) erl_lint.erl:448: :erl_lint.exprs_opt/3
    (stdlib) erl_eval.erl:173: :erl_eval.check_command/
```

By removing the `lineL -1` the issue goes away. There is also no warning
when doing this so it can be safely removed.