### PR TITLE
Add Sequence.reset

### DIFF
--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -84,7 +84,11 @@ defmodule ExMachina do
   @doc """
   Shortcut for creating unique string values. Similar to sequence/2
 
-  For more customization of the generated string, see ExMachina.sequence/2
+  If you need to customize the returned string, see `ExMachina.sequence/2`.
+
+  Note that sequences keep growing and are *not* reset by ExMachina. Most of the
+  time you won't need to reset the sequence, but when you do need to reset them,
+  you can use `ExMachina.Sequence.reset/0`.
 
   ## Examples
 
@@ -97,6 +101,7 @@ defmodule ExMachina do
 
       def article_factory do
         %Article{
+          # Will generate "Article Title0" then "Article Title1", etc.
           title: sequence("Article Title")
         }
       end

--- a/lib/ex_machina/sequence.ex
+++ b/lib/ex_machina/sequence.ex
@@ -3,12 +3,37 @@ defmodule ExMachina.Sequence do
     Agent.start_link(fn -> HashDict.new end, name: __MODULE__)
   end
 
+  @doc """
+  Reset all sequences so that the next sequence starts from 0
+
+  ## Example
+
+      ExMachina.Sequence.next("joe") # "joe0"
+      ExMachina.Sequence.next("joe") # "joe1"
+
+      Sequence.reset
+
+      ExMachina.Sequence.next("joe") # resets so the return value is "joe0"
+
+  If you want to reset sequences at the beginning of every test, put it in a
+  `setup` block in your test.
+
+     setup do
+       ExMachina.Sequence.reset
+     end
+  """
+  def reset do
+    Agent.update(__MODULE__, fn(_) -> HashDict.new end)
+  end
+
+  @doc false
   def next(sequence_name) when is_binary(sequence_name) do
     next sequence_name, fn(n)->
       sequence_name <> to_string(n)
     end
   end
 
+  @doc false
   def next(sequence_name) do
     raise(
       ArgumentError,
@@ -16,6 +41,7 @@ defmodule ExMachina.Sequence do
     )
   end
 
+  @doc false
   def next(sequence_name, formatter) do
     Agent.get_and_update(__MODULE__, fn(sequences) ->
       current_value = HashDict.get(sequences, sequence_name, 0)

--- a/test/ex_machina/sequence_test.exs
+++ b/test/ex_machina/sequence_test.exs
@@ -4,7 +4,7 @@ defmodule ExMachina.SequenceTest do
   alias ExMachina.Sequence
 
   setup do
-    Agent.update(ExMachina.Sequence, fn(_) -> HashDict.new end)
+    Sequence.reset
   end
 
   test "increments the sequence each time it is called" do
@@ -28,5 +28,13 @@ defmodule ExMachina.SequenceTest do
     assert_raise ArgumentError, ~r/must be a string/, fn ->
       Sequence.next(:not_a_string)
     end
+  end
+
+  test "can reset sequences" do
+    Sequence.next("joe")
+
+    Sequence.reset
+
+    assert "joe0" == Sequence.next("joe")
   end
 end


### PR DESCRIPTION
Closes https://github.com/thoughtbot/ex_machina/issues/120

`Sequence.reset` can be run in a `setup` block to make sure sequences
are reset between tests. This often times is not needed, but when it is,
it's handy to have. See the linked issue above for more details.