### PR TITLE
Allow passing a func to customize structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,26 +117,37 @@ Using factories ([check out the docs](http://hexdocs.pm/ex_machina/ExMachina.htm
 
 ```elixir
 # `attrs` are automatically merged in for all build/insert functions. 
-# Note, a __func__ can be set in the attrs Map. This func will be 
-# executed after the object is created and the rest of the map has been
-# merged. Useful only if you need to alter the generated struct in a 
-# manner that won't work with struct! or Map.merge. 
-# eg: Suppose you need to set the prefix on an object before inserting it:
-insert(:user, %{__func__: fn(user) -> Ecto.put_meta(user, prefix: "prefix") end})
 
 
 # `build*` returns an unsaved comment.
 # Associated records defined on the factory are built.
 attrs = %{body: "A comment!"} # attrs is optional. Also accepts a keyword list.
+func = fn(comment) -> Map.put(comment, :text, "different text") end # func is optional
 build(:comment, attrs)
+build(:comment, func)
+build(:comment, attrs, func)
+
 build_pair(:comment, attrs)
+build_pair(:comment, func)
+build_pair(:comment, attrs, func)
+
 build_list(3, :comment, attrs)
+build_list(3, :comment, func)
+build_list(3, :comment, attrs, func)
 
 # `insert*` returns an inserted comment. Only works with ExMachina.Ecto
 # Associated records defined on the factory are inserted as well.
 insert(:comment, attrs)
+insert(:comment, func)
+insert(:comment, func, attrs)
+
 insert_pair(:comment, attrs)
+insert_pair(:comment, func)
+insert_pair(:comment, func, attrs)
+
 insert_list(3, :comment, attrs)
+insert_list(3, :comment, func)
+insert_list(3, :comment, func, attrs)
 
 # `params_for` returns a plain map without any Ecto specific attributes.
 # This is only available when using `ExMachina.Ecto`.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,14 @@ end
 Using factories ([check out the docs](http://hexdocs.pm/ex_machina/ExMachina.html) for more details):
 
 ```elixir
-# `attrs` are automatically merged in for all build/insert functions.
+# `attrs` are automatically merged in for all build/insert functions. 
+# Note, a __func__ can be set in the attrs Map. This func will be 
+# executed after the object is created and the rest of the map has been
+# merged. Useful only if you need to alter the generated struct in a 
+# manner that won't work with struct! or Map.merge. 
+# eg: Suppose you need to set the prefix on an object before inserting it:
+insert(:user, %{__func__: fn(user) -> Ecto.put_meta(user, prefix: "prefix") end})
+
 
 # `build*` returns an unsaved comment.
 # Associated records defined on the factory are built.

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -38,16 +38,28 @@ defmodule ExMachina do
 
       import ExMachina, only: [sequence: 1, sequence: 2]
 
-      def build(factory_name, attrs \\ %{}) do
-        ExMachina.build(__MODULE__, factory_name, attrs)
+      def build(factory_name, funcattr \\ %{}) do
+        ExMachina.build(__MODULE__, factory_name, funcattr)
       end
 
-      def build_pair(factory_name, attrs \\ %{}) do
-        ExMachina.build_pair(__MODULE__, factory_name, attrs)
+      def build(factory_name, attrs, func) do
+        ExMachina.build(__MODULE__, factory_name, attrs, func)
       end
 
-      def build_list(number_of_factories, factory_name, attrs \\ %{}) do
-        ExMachina.build_list(__MODULE__, number_of_factories, factory_name, attrs)
+      def build_pair(factory_name, funcattr \\ %{}) do
+        ExMachina.build_pair(__MODULE__, factory_name, funcattr)
+      end
+
+      def build_pair(factory_name, attrs, func) do
+        ExMachina.build_pair(__MODULE__, factory_name, attrs, func)
+      end
+
+      def build_list(number_of_factories, factory_name, funcattr \\ %{}) do
+        ExMachina.build_list(__MODULE__, number_of_factories, factory_name, funcattr)
+      end
+
+      def build_list(number_of_factories, factory_name, attrs, func) do
+        ExMachina.build_list(__MODULE__, number_of_factories, factory_name, attrs, func)
       end
 
       def create(_) do
@@ -133,26 +145,33 @@ defmodule ExMachina do
 
       # Returns %{name: "John Doe", admin: true}
       build(:user, admin: true)
+
+      # Returns %{name: "Jim Doe", admin: false}
+      build(:user, fn(user) -> Map.put(user, :name, "Jim Doe") end)
+
+      # Returns %{name: "Jim Doe", admin: true}
+      build(:user, %{admin: true}, fn(user) -> Map.put(user, :name, "Jim Doe") end)
   """
-  def build(module, factory_name, attrs \\ %{}) do
+  def build(module, factory_name, func)  when is_function(func), do: build(module, factory_name, %{}, func)
+  def build(module, factory_name, attrs) when is_map(attrs) or is_list(attrs), do: build(module, factory_name, attrs, &identity/1)
+  def build(module, factory_name, attrs, func) do
     attrs = Enum.into(attrs, %{})
     function_name = Atom.to_string(factory_name) <> "_factory" |> String.to_atom
     if Code.ensure_loaded?(module) && function_exported?(module, function_name, 0) do
-      apply(module, function_name, []) |> do_merge(attrs)
+      apply(module, function_name, []) |> do_merge(attrs) |> func.()
     else
       raise UndefinedFactoryError, factory_name
     end
   end
 
-  defp do_merge(record, %{__func__: func}=attrs) do
-    func.(do_merge(record, Map.delete(attrs, :__func__)))
-  end
   defp do_merge(%{__struct__: _} = record, attrs) do
     struct!(record, attrs)
   end
   defp do_merge(record, attrs) do
     Map.merge(record, attrs)
   end
+
+  defp identity(obj), do: obj
 
   @doc """
   Builds and returns 2 records with the passed in factory_name and attrs
@@ -161,9 +180,13 @@ defmodule ExMachina do
 
       # Returns a list of 2 users
       build_pair(:user)
+)
   """
-  def build_pair(module, factory_name, attrs \\ %{}) do
-    ExMachina.build_list(module, 2, factory_name, attrs)
+  def build_pair(module, factory_name, funcattrs) do
+    ExMachina.build_list(module, 2, factory_name, funcattrs)
+  end
+  def build_pair(module, factory_name, attrs, func) do
+    ExMachina.build_list(module, 2, factory_name, attrs, func)
   end
 
   @doc """
@@ -174,9 +197,15 @@ defmodule ExMachina do
       # Returns a list of 3 users
       build_list(3, :user)
   """
-  def build_list(module, number_of_factories, factory_name, attrs \\ %{}) do
+  def build_list(module, number_of_factories, factory_name, func) when is_function(func) do
+    build_list(module, number_of_factories, factory_name, %{}, func)
+  end
+  def build_list(module, number_of_factories, factory_name, attrs) when is_map(attrs) or is_list(attrs) do
+    build_list(module, number_of_factories, factory_name, attrs, &identity/1)
+  end
+  def build_list(module, number_of_factories, factory_name, attrs, func) do
     Enum.map(1..number_of_factories, fn(_) ->
-      ExMachina.build(module, factory_name, attrs)
+      ExMachina.build(module, factory_name, attrs, func)
     end)
   end
 

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -144,6 +144,9 @@ defmodule ExMachina do
     end
   end
 
+  defp do_merge(record, %{__func__: func}=attrs) do
+    func.(do_merge(record, Map.delete(attrs, :__func__)))
+  end
   defp do_merge(%{__struct__: _} = record, attrs) do
     struct!(record, attrs)
   end

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -71,6 +71,22 @@ defmodule ExMachinaTest do
     }
   end
 
+  test "build/2 invokes passed in proc" do
+    assert Factory.build(:user, %{__func__: fn(user) -> Map.put(user, :name, "Jim Doe") end}) == %{
+      id: 3,
+      name: "Jim Doe",
+      admin: false
+    }
+  end
+
+  test "build/2 invokes passed in proc, and merges the rest of the map as usual" do
+    assert Factory.build(:user, %{admin: true, __func__: fn(user) -> Map.put(user, :name, "Jim Doe") end}) == %{
+      id: 3,
+      name: "Jim Doe",
+      admin: true
+    }
+  end
+
   test "build/2 raises if passing invalid keys to a struct factory" do
     assert_raise KeyError, fn ->
       Factory.build(:struct, doesnt_exist: true)

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -72,15 +72,15 @@ defmodule ExMachinaTest do
   end
 
   test "build/2 invokes passed in proc" do
-    assert Factory.build(:user, %{__func__: fn(user) -> Map.put(user, :name, "Jim Doe") end}) == %{
+    assert Factory.build(:user, fn(user) -> Map.put(user, :name, "Jim Doe") end) == %{
       id: 3,
       name: "Jim Doe",
       admin: false
     }
   end
 
-  test "build/2 invokes passed in proc, and merges the rest of the map as usual" do
-    assert Factory.build(:user, %{admin: true, __func__: fn(user) -> Map.put(user, :name, "Jim Doe") end}) == %{
+  test "build/3 invokes passed in proc, and merges the rest of the map as usual" do
+    assert Factory.build(:user, %{admin: true}, fn(user) -> Map.put(user, :name, "Jim Doe") end) == %{
       id: 3,
       name: "Jim Doe",
       admin: true
@@ -93,7 +93,18 @@ defmodule ExMachinaTest do
     end
   end
 
-  test "build_pair/2 builds 2 factories" do
+  test "build_pair/1 builds 2 factories" do
+    records = Factory.build_pair(:user)
+
+    expected_record = %{
+      id: 3,
+      name: "John Doe",
+      admin: false
+    }
+    assert records == [expected_record, expected_record]
+  end
+
+  test "build_pair/2 builds 2 factories merging the map" do
     records = Factory.build_pair(:user, admin: true)
 
     expected_record = %{
@@ -104,12 +115,67 @@ defmodule ExMachinaTest do
     assert records == [expected_record, expected_record]
   end
 
-  test "build_list/3 builds the factory the passed in number of times" do
-    records = Factory.build_list(3, :user, admin: true)
+  test "build_pair/2 builds 2 factories running the func" do
+    records = Factory.build_pair(:user, fn(rec) -> Map.put(rec, :name, "Jim Doe") end)
+
+    expected_record = %{
+      id: 3,
+      name: "Jim Doe",
+      admin: false
+    }
+    assert records == [expected_record, expected_record]
+  end
+
+  test "build_pair/3 builds 2 factories" do
+    records = Factory.build_pair(:user, [admin: true], fn(rec) -> Map.put(rec, :name, "Jim Doe") end)
+
+    expected_record = %{
+      id: 3,
+      name: "Jim Doe",
+      admin: true
+    }
+    assert records == [expected_record, expected_record]
+  end
+
+  test "build_list/2 builds the factory the passed in number of times" do
+    records = Factory.build_list(3, :user)
 
     expected_record = %{
       id: 3,
       name: "John Doe",
+      admin: false
+    }
+    assert records == [expected_record, expected_record, expected_record]
+  end
+
+  test "build_list/3 builds the factory the passed in number of times merging map" do
+    records = Factory.build_list(3, :user, %{admin: true})
+
+    expected_record = %{
+      id: 3,
+      name: "John Doe",
+      admin: true
+    }
+    assert records == [expected_record, expected_record, expected_record]
+  end
+
+  test "build_list/3 builds the factory the passed in number of times running the func" do
+    records = Factory.build_list(3, :user, fn(rec) -> Map.put(rec, :name, "Jim Doe") end)
+
+    expected_record = %{
+      id: 3,
+      name: "Jim Doe",
+      admin: false
+    }
+    assert records == [expected_record, expected_record, expected_record]
+  end
+
+  test "build_list/4 builds the factory the passed in number of times" do
+    records = Factory.build_list(3, :user, %{admin: true}, fn(rec) -> Map.put(rec, :name, "Jim Doe") end)
+
+    expected_record = %{
+      id: 3,
+      name: "Jim Doe",
       admin: true
     }
     assert records == [expected_record, expected_record, expected_record]


### PR DESCRIPTION
The 'why' for this is in #175, but in a nutshell, the problem is that merging maps doesn't work in all cases. For example:
- tuples
- nested maps (it doesn't deep-merge)

Tuples are important in the Ecto world, because Ecto.Schema.Metadata.source is a tuple of (prefix, tablename)

More info in the issue:
Resolves: #175 
