### PR TITLE
Fix a couple of new Elixir 1.4 warnings

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -13,7 +13,7 @@ defmodule ExMachina.Ecto do
   More in-depth examples are in the [README](README.html).
   """
   defmacro __using__(opts) do
-    verify_ecto_dep
+    verify_ecto_dep()
     if repo = Keyword.get(opts, :repo) do
       quote do
         use ExMachina

--- a/test/ex_machina/strategy_test.exs
+++ b/test/ex_machina/strategy_test.exs
@@ -5,7 +5,7 @@ defmodule ExMachina.StrategyTest do
     use ExMachina.Strategy, function_name: :json_encode
 
     def handle_json_encode(record, opts) do
-      send self, {:handle_json_encode, record, opts}
+      send self(), {:handle_json_encode, record, opts}
     end
   end
 


### PR DESCRIPTION
In Elixir 1.4, local arity 0 functions which are called without parentheses raises a warning. Just a quick PR to satisfy these warnings by explicitly using parentheses where applicable.