### PR TITLE
Drop unbuilt has many throughs in params functions

### DIFF
--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -89,7 +89,7 @@ defmodule ExMachina.EctoTest do
     }]
   end
 
-  test "params_for/2 deletes has_one associations" do
+  test "params_for/2 converts has_one associations to params" do
     article = TestFactory.build(:article)
 
     user_params = TestFactory.params_for(:user, best_article: article)

--- a/test/support/models/user.ex
+++ b/test/support/models/user.ex
@@ -8,6 +8,7 @@ defmodule ExMachina.User do
     field :password, :string, virtual: true
 
     has_many :articles, ExMachina.Article
+    has_many :editors, through: [:articles, :editor]
     has_one :best_article, ExMachina.Article
   end
 end


### PR DESCRIPTION
Drop unbuilt has many throughs in params functions

Prior to this commit, a has_many through relationship on the model was not dropped from the model. We now delete unbuilt has-many throughs.

Since we already test expected output from various params functions, simply adding the has_many through relation to the model was enough to reproduce errors in the tests.