### PR TITLE
Clarify where to import factory module in Phoenix

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ string_params_with_assocs(:comment, attrs)
 # Example of use in Phoenix with a factory that uses ExMachina.Ecto
 defmodule MyApp.MyModuleTest do
   use MyApp.ConnCase
-  # You can also import this in your MyApp.ConnCase if using Phoenix
+  # You can also import this in your MyApp.ConnCase (inside the using block)
+  # if using Phoenix
   import MyApp.Factory
 
   test "shows comments for an article" do

--- a/README.md
+++ b/README.md
@@ -152,8 +152,7 @@ string_params_with_assocs(:comment, attrs)
 # Example of use in Phoenix with a factory that uses ExMachina.Ecto
 defmodule MyApp.MyModuleTest do
   use MyApp.ConnCase
-  # You can also import this in your MyApp.ConnCase (inside the using block)
-  # if using Phoenix
+  # If using Phoenix, import this inside the using block in MyApp.ConnCase
   import MyApp.Factory
 
   test "shows comments for an article" do


### PR DESCRIPTION
Being new to Phoenix I spent some time this morning trying to figure out why I got the error `undefined function insert/1` when setting up ExMachina. Turns out I'd put the `import MyApp.Factory` into the body of MyApp.ConnCase instead of in the `using` block. 

This PR adds a note to the readme in the hope of saving other developers the time it took to figure that out.

Thanks for the great library!