### PR TITLE
Fix link to latest published docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ExMachina makes it easy to create test data and associations. It works great
 with Ecto, but is configurable to work with any persistence library.
 
 > **This README follows master, which may not be the currently published version**. Here are the
-[docs for the latest published version of ExMachina](https://hexdocs.pm/ex_machina/README.html).
+[docs for the latest published version of ExMachina](https://hexdocs.pm/ex_machina/readme.html).
 
 ## Installation
 


### PR DESCRIPTION
I clicked on the link to the *docs for the latest published version of ExMachina* and hexdocs.pm gave me a 404. Turns out `README.html` should be `readme.html`. This PR fixes the link.

Let me know if I should open an issue. I did not open an issue in the first place, because I felt this is a really minor fix.