### PR TITLE
Strip embeds in params_for

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -152,18 +152,12 @@ defmodule ExMachina.Ecto do
   end
 
 
-  defp recursively_strip(record = %{__meta__: %{__struct__: Ecto.Schema.Metadata}}) do
+  defp recursively_strip(record = %{__struct__: _}) do
     record
     |> set_persisted_belongs_to_ids
     |> handle_assocs
     |> handle_embeds
     |> drop_ecto_fields
-    |> drop_fields_with_nil_values
-  end
-
-  defp recursively_strip(embedded_record = %{__struct__: _}) do
-    embedded_record
-    |> Map.from_struct
     |> drop_fields_with_nil_values
   end
 
@@ -219,7 +213,7 @@ defmodule ExMachina.Ecto do
     end
   end
 
-  defp set_persisted_belongs_to_ids(record = %{__struct__: struct, __meta__: %{__struct__: Ecto.Schema.Metadata}}) do
+  defp set_persisted_belongs_to_ids(record = %{__struct__: struct}) do
     Enum.reduce struct.__schema__(:associations), record, fn(association_name, record) ->
       association = struct.__schema__(:association, association_name)
 
@@ -240,7 +234,7 @@ defmodule ExMachina.Ecto do
     Map.put(record, association.owner_key, primary_key)
   end
 
-  defp insert_belongs_to_assocs(record = %{__struct__: struct, __meta__: %{__struct__: Ecto.Schema.Metadata}}, module) do
+  defp insert_belongs_to_assocs(record = %{__struct__: struct}, module) do
     Enum.reduce struct.__schema__(:associations), record, fn(association_name, record) ->
       case struct.__schema__(:association, association_name) do
         association = %{__struct__: Ecto.Association.BelongsTo} ->
@@ -263,7 +257,7 @@ defmodule ExMachina.Ecto do
   end
 
   @doc false
-  def drop_ecto_fields(record = %{__struct__: struct, __meta__: %{__struct__: Ecto.Schema.Metadata}}) do
+  def drop_ecto_fields(record = %{__struct__: struct}) do
     record
     |> Map.from_struct
     |> Map.delete(:__meta__)

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -117,6 +117,13 @@ defmodule ExMachina.EctoTest do
     assert comment_params.links == [%{url: "https://thoughtbot.com", rating: 5}, %{url: "https://github.com", rating: 4}]
   end
 
+  test "params_for/2 handles nested embeds" do
+    links = [%ExMachina.Link{url: "https://thoughtbot.com", rating: 5, metadata: %ExMachina.Metadata{text: "foo"}}]
+    comment_params = TestFactory.params_for(:comment_with_embedded_assocs, links: links)
+    assert List.first(comment_params.links).metadata == %{text: "foo"}
+  end
+
+
   test "string_params_for/2 produces maps similar to ones built with params_for/2, but the keys are strings" do
     assert TestFactory.string_params_for(:user) == %{
       "name" => "John Doe",

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -105,6 +105,18 @@ defmodule ExMachina.EctoTest do
     assert user_params.articles == [%{title: article.title}]
   end
 
+  test "params_for/2 converts embeds_one into a map" do
+    author = %ExMachina.Author{name: "Author", salary: 1.0}
+    comment_params = TestFactory.params_for(:comment_with_embedded_assocs, author: author)
+    assert comment_params.author == %{name: "Author", salary: 1.0}
+  end
+
+  test "params_for/2 converts embeds_many into a list of maps" do
+    links = [%ExMachina.Link{url: "https://thoughtbot.com", rating: 5}, %ExMachina.Link{url: "https://github.com", rating: 4}]
+    comment_params = TestFactory.params_for(:comment_with_embedded_assocs, links: links)
+    assert comment_params.links == [%{url: "https://thoughtbot.com", rating: 5}, %{url: "https://github.com", rating: 4}]
+  end
+
   test "string_params_for/2 produces maps similar to ones built with params_for/2, but the keys are strings" do
     assert TestFactory.string_params_for(:user) == %{
       "name" => "John Doe",

--- a/test/support/models/comment.ex
+++ b/test/support/models/comment.ex
@@ -22,5 +22,15 @@ defmodule ExMachina.Link do
   embedded_schema do
     field :url
     field :rating, :decimal
+    embeds_one :metadata, ExMachina.Metadata
+  end
+end
+
+defmodule ExMachina.Metadata do
+  use Ecto.Schema
+
+  embedded_schema do
+    field :image_url, :string
+    field :text, :string
   end
 end


### PR DESCRIPTION
I had an issue that `params_for` didn't work for my model that had embed fields in it; you have to strip embed structs down to plain maps for them to be allowed inside a changeset.

I removed the pattern matching dealing with `Ecto.Schema.Metadata` because `embedded_schema`s don't have metadata; it should always be safe as all traversed objects have Ecto schemas by the context of the `recursively_strip` method.
