### PR TITLE
Ecto: Support bare maps as values for embeds. Support lists of bare maps

### DIFF
--- a/lib/ex_machina/ecto_strategy.ex
+++ b/lib/ex_machina/ecto_strategy.ex
@@ -49,9 +49,12 @@ defmodule ExMachina.EctoStrategy do
   defp cast_field(field, %{__struct__: schema} = struct) do
     field_type = schema.__schema__(:type, field)
     virtual_field? = !field_type
+    embed_type = schema.__schema__(:embed, field)
+    embed_field? = !!embed_type
+
     value = Map.get(struct, field)
 
-    if virtual_field? do
+    if virtual_field? || embed_field? do
       value
     else
       cast_value(field_type, value, struct)
@@ -90,7 +93,8 @@ defmodule ExMachina.EctoStrategy do
         cast(original_assoc)
 
       %{} ->
-        assoc_type = schema.__schema__(:association, assoc).related
+        assoc_reflection = schema.__schema__(:association, assoc) || schema.__schema__(:embed, assoc)
+        assoc_type = assoc_reflection.related
         assoc_type |> struct |> Map.merge(original_assoc) |> cast
 
       list when is_list(list)->

--- a/priv/test_repo/migrations/1_migrate_all.exs
+++ b/priv/test_repo/migrations/1_migrate_all.exs
@@ -17,6 +17,7 @@ defmodule ExMachina.TestRepo.Migrations.MigrateAll do
     end
 
     create table(:comments) do
+      add :article_id, :integer
       add :author, :map
       add :links, {:array, :map}, default: []
     end

--- a/test/ex_machina/ecto_strategy_test.exs
+++ b/test/ex_machina/ecto_strategy_test.exs
@@ -91,6 +91,12 @@ defmodule ExMachina.EctoStrategyTest do
     assert model.author.net_worth == Decimal.new(300)
   end
 
+  test "insert/1 casts bare maps for embeds" do
+    model = TestFactory.insert(:comment_with_embedded_assocs, author: %{salary: 300})
+
+    assert model.author.salary == Decimal.new(300)
+  end
+
   test "insert/1 casts associations recursively" do
     editor = TestFactory.build(:user, net_worth: 300)
     article = TestFactory.build(:article, editor: editor)

--- a/test/ex_machina/ecto_strategy_test.exs
+++ b/test/ex_machina/ecto_strategy_test.exs
@@ -91,11 +91,23 @@ defmodule ExMachina.EctoStrategyTest do
     assert model.author.net_worth == Decimal.new(300)
   end
 
+  test "insert/1 casts lists of bare maps" do
+    model = TestFactory.insert(:article, comments: [%{author: %{name: "John Doe", salary: 300}}])
+
+    assert hd(model.comments).author.salary == Decimal.new(300)
+  end
+
   test "insert/1 casts bare maps for embeds" do
     model = TestFactory.insert(:comment_with_embedded_assocs, author: %{salary: 300})
 
     assert model.author.salary == Decimal.new(300)
   end
+
+  test "insert/1 casts lists of bare maps for embeds" do
+    model = TestFactory.insert(:comment_with_embedded_assocs, links: [%{url: "http://thoughtbot.com", rating: 5}])
+    assert hd(model.links).rating == Decimal.new(5)
+  end
+
 
   test "insert/1 casts associations recursively" do
     editor = TestFactory.build(:user, net_worth: 300)

--- a/test/support/models/article.ex
+++ b/test/support/models/article.ex
@@ -8,5 +8,6 @@ defmodule ExMachina.Article do
     belongs_to :author, ExMachina.User
     belongs_to :editor, ExMachina.User
     belongs_to :publisher, ExMachina.Publisher
+    has_many :comments, ExMachina.Comment
   end
 end

--- a/test/support/models/comment.ex
+++ b/test/support/models/comment.ex
@@ -2,6 +2,7 @@ defmodule ExMachina.Comment do
   use Ecto.Schema
 
   schema "comments" do
+    belongs_to :article, ExMachina.Article
     embeds_one :author, ExMachina.Author
     embeds_many :links, ExMachina.Link
   end


### PR DESCRIPTION
The first one was only supported for assocs. 

Passing a bare map for an embed first crashed in `cast_value` because it can't be cast trivially, then in `cast_assoc` because the bare map handling code expects an association only.

The second one wasn't supported for either assocs or embeds, because bare maps inside of the list weren't properly casted.


Added tests and fixed.