### PR TITLE
EctoStrategy: Fix error message in cast_value/3

### DIFF
--- a/lib/ex_machina/ecto_strategy.ex
+++ b/lib/ex_machina/ecto_strategy.ex
@@ -63,7 +63,7 @@ defmodule ExMachina.EctoStrategy do
       {:ok, value} ->
         value
       _ ->
-        raise "Failed to cast `#{value}` of type #{field_type} in #{inspect struct}."
+        raise "Failed to cast `#{inspect value}` of type #{inspect field_type} in #{inspect struct}."
     end
   end
 

--- a/test/ex_machina/ecto_strategy_test.exs
+++ b/test/ex_machina/ecto_strategy_test.exs
@@ -121,7 +121,7 @@ defmodule ExMachina.EctoStrategyTest do
   end
 
   test "insert/1 raises a friendly error when casting invalid types" do
-    message = ~r/Failed to cast `invalid` of type Elixir.ExMachina.InvalidType/
+    message = ~r/Failed to cast `:invalid` of type ExMachina.InvalidType/
     assert_raise RuntimeError, message, fn ->
       TestFactory.insert(:invalid_cast, invalid: :invalid)
     end


### PR DESCRIPTION
Found this while debugging #206 - in Elixir you can only interpolate values if they implement the `String.Chars` protocol.