### PR TITLE
Fix user has many posts association

### DIFF
--- a/lib/ex_machina/ecto_strategy.ex
+++ b/lib/ex_machina/ecto_strategy.ex
@@ -31,8 +31,8 @@ defmodule ExMachina.EctoStrategy do
 
     record
     |> cast_all_fields
-    |> cast_all_assocs(field_set_by_parent)
     |> skip_already_set_assoc(parent_assoc)
+    |> cast_all_assocs(nil)
   end
 
   defp assoc_set_by_parent(%{__struct__: schema}, field_set_by_parent) do

--- a/lib/ex_machina/ecto_strategy.ex
+++ b/lib/ex_machina/ecto_strategy.ex
@@ -14,7 +14,7 @@ defmodule ExMachina.EctoStrategy do
 
   def handle_insert(%{__meta__: %{__struct__: Ecto.Schema.Metadata}} = record, %{repo: repo}) do
     record
-    |> cast
+    |> cast(nil)
     |> repo.insert!
   end
 
@@ -26,10 +26,29 @@ defmodule ExMachina.EctoStrategy do
     raise "expected :repo to be given to ExMachina.EctoStrategy"
   end
 
-  defp cast(record) do
+  defp cast(record, field_set_by_parent) do
+    parent_assoc = assoc_set_by_parent(record, field_set_by_parent)
+
     record
     |> cast_all_fields
-    |> cast_all_assocs
+    |> cast_all_assocs(field_set_by_parent)
+    |> skip_already_set_assoc(parent_assoc)
+  end
+
+  defp assoc_set_by_parent(%{__struct__: schema}, field_set_by_parent) do
+    if field_set_by_parent do
+      schema.__schema__(:associations)
+      |> Enum.find(fn(assoc) ->
+        foreign_key =
+          :association
+          |> schema.__schema__(assoc)
+          |> Map.get(:owner_key, nil)
+        foreign_key == field_set_by_parent end)
+    end
+  end
+
+  defp skip_already_set_assoc(record, parent_assoc) do
+    Map.delete(record, parent_assoc)
   end
 
   defp cast_all_fields(struct) do
@@ -70,37 +89,49 @@ defmodule ExMachina.EctoStrategy do
     end
   end
 
-  defp cast_all_assocs(%{__struct__: schema} = struct) do
+  defp cast_all_assocs(%{__struct__: schema} = struct, field_set_by_parent) do
     assocs = get_schema_assocs(schema)
 
     Enum.reduce(assocs, struct, fn(assoc, struct) ->
-      casted_value = struct |> Map.get(assoc) |> cast_assoc(assoc, struct)
+      casted_value = struct |> Map.get(assoc) |> cast_assoc(assoc, struct, field_set_by_parent)
 
       Map.put(struct, assoc, casted_value)
     end)
   end
 
-  defp cast_assoc(original_assoc, assoc_key, %{__struct__: schema} = struct) do
+  defp cast_assoc(original_assoc, assoc_key, %{__struct__: schema} = struct, field_set_by_parent) do
     case original_assoc do
       has_or_embeds_many when is_list(has_or_embeds_many) ->
-        Enum.map(has_or_embeds_many, &(cast_assoc(&1, assoc_key, struct)))
-
-      %{__meta__: %{__struct__: Ecto.Schema.Metadata, state: :built}} ->
-        cast(original_assoc)
+        Enum.map(has_or_embeds_many,
+          &(cast_assoc(&1, assoc_key, struct, foreign_key(schema, assoc_key))))
 
       %{__struct__: Ecto.Association.NotLoaded} ->
         original_assoc
 
       %{__struct__: _} ->
-        cast(original_assoc)
+        cast(original_assoc, field_set_by_parent)
 
       %{} ->
-        assoc_reflection = schema.__schema__(:association, assoc_key) || schema.__schema__(:embed, assoc_key)
-        assoc_type = assoc_reflection.related
-        assoc_type |> struct() |> Map.merge(original_assoc) |> cast()
+        schema
+        |> assoc_type(assoc_key)
+        |> struct()
+        |> Map.merge(original_assoc)
+        |> cast(field_set_by_parent)
 
       nil -> nil
     end
+  end
+
+  defp foreign_key(schema, assoc_key) do
+    assoc_reflection = schema.__schema__(:association, assoc_key)
+    if assoc_reflection do
+      assoc_reflection.related_key
+    end
+  end
+
+  defp assoc_type(schema, assoc_key) do
+    assoc_reflection = schema.__schema__(:association, assoc_key) || schema.__schema__(:embed, assoc_key)
+    assoc_reflection.related
   end
 
   defp get_schema_assocs(schema) do

--- a/test/support/models/user.ex
+++ b/test/support/models/user.ex
@@ -7,7 +7,7 @@ defmodule ExMachina.User do
     field :net_worth, :decimal
     field :password, :string, virtual: true
 
-    has_many :articles, ExMachina.Article
+    has_many :articles, ExMachina.Article, foreign_key: :author_id
     has_many :editors, through: [:articles, :editor]
     has_one :best_article, ExMachina.Article
   end


### PR DESCRIPTION
This is my first stab at solving #221 

In case where user has many articles and `article_factory` defines `build(:user)`, it should be still possible to call it like this:

    Factory.insert(:user, name: "parent user", articles: [build(:article)])

In that case `ex_machina` should ignore the `build(:user)` part of `article_factory`, because it is already set by its parent `user` in the tree of structs that we want to isnert.

This PR extends `EctoStrategy.cast` function to take additional argument `field_set_by_parent`.
This argument is set to foreign key of `has_many` relation. (I am pretty sure we will need another case for `has_one` relation, but we can go one step at a time).
Foreign key is the only thing that connects relation "User has_many Articles" with relation "Article belongs_to User" that we want to skip.

Please let me know if you like this solution and if you think I can make it better in any way.
Thanks in advance for the time spent on review!