### PR TITLE
So that we can use list sequences, fixes #223

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ defmodule MyApp.Factory do
     %MyApp.User{
       name: "Jane Smith",
       email: sequence(:email, &"email-#{&1}@example.com"),
+      role: sequence(:role, ["admin", "user", "other"]),
     }
   end
 

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -121,7 +121,9 @@ defmodule ExMachina do
       def user_factory do
         %{
           # Will generate "me-0@example.com" then "me-1@example.com", etc.
-          email: sequence(:email, &"me-\#{&1}@foo.com")
+          email: sequence(:email, &"me-\#{&1}@foo.com"),
+          # Will generate "admin" then "user", "other", "admin" etc.
+          role: sequence(:role, ["admin", "user", "other"])
         }
       end
   """

--- a/lib/ex_machina/sequence.ex
+++ b/lib/ex_machina/sequence.ex
@@ -15,6 +15,15 @@ defmodule ExMachina.Sequence do
 
       ExMachina.Sequence.next("joe") # resets so the return value is "joe0"
 
+  You can use list as well
+
+      ExMachina.Sequence.next(["A", "B"]) # "A"
+      ExMachina.Sequence.next(["A", "B"]) # "B"
+
+      Sequence.reset
+
+      ExMachina.Sequence.next(["A", "B"]) # resets so the return value is "A"
+
   If you want to reset sequences at the beginning of every test, put it in a
   `setup` block in your test.
 
@@ -37,6 +46,18 @@ defmodule ExMachina.Sequence do
       ArgumentError,
       "Sequence name must be a string, got #{inspect sequence_name} instead"
     )
+  end
+
+  @doc false
+  def next(sequence_name, [_|_] = list) do
+    length = length(list)
+    Agent.get_and_update __MODULE__, fn(sequences) ->
+      current_value = Map.get(sequences, sequence_name, 0)
+      index = rem(current_value, length)
+      new_sequences = Map.put(sequences, sequence_name, index + 1)
+      {value, _} = List.pop_at(list, index)
+      {value, new_sequences}
+    end
   end
 
   @doc false

--- a/test/ex_machina/sequence_test.exs
+++ b/test/ex_machina/sequence_test.exs
@@ -12,6 +12,13 @@ defmodule ExMachina.SequenceTest do
     assert "joe1" == Sequence.next(:name, &"joe#{&1}")
   end
 
+  test "traverses a list each time it is called" do
+    assert "A" == Sequence.next(:name, ["A", "B", "C"])
+    assert "B" == Sequence.next(:name, ["A", "B", "C"])
+    assert "C" == Sequence.next(:name, ["A", "B", "C"])
+    assert "A" == Sequence.next(:name, ["A", "B", "C"])
+  end
+
   test "updates different sequences independently" do
     assert "joe0" == Sequence.next(:name, &"joe#{&1}")
     assert "joe1" == Sequence.next(:name, &"joe#{&1}")


### PR DESCRIPTION
Now we can use list sequences, as proposed in #223

```
  def user_factory do
    %MyApp.User{
      name: "Jane Smith",
      email: sequence(:email, &"email-#{&1}@example.com"),
      role: sequence(:role, ["admin", "user", "other"]),
    }
  end
```