### PR TITLE
DSL for Factories

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{ex,exs}]
+indent_style = space
+indent_size = 2
+
+[*.{json,yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -36,7 +36,7 @@ defmodule ExMachina do
     quote do
       @before_compile unquote(__MODULE__)
 
-      import ExMachina, only: [sequence: 1, sequence: 2]
+      import ExMachina, only: [sequence: 1, sequence: 2, factory: 2]
 
       def build(factory_name, attrs \\ %{}) do
         ExMachina.build(__MODULE__, factory_name, attrs)
@@ -127,6 +127,22 @@ defmodule ExMachina do
   """
   def sequence(name, formatter), do: ExMachina.Sequence.next(name, formatter)
 
+  @doc """
+  Creates a function following the requirement of build/3
+
+  ## Example
+      # Will generate a user_factory function
+      factory :user do
+        %{username: sequence("user")}
+      end
+  """
+  defmacro factory(name, do: generator) do
+    name = build_function_name(name)
+    
+    quote do
+      def unquote(name)(), do: unquote(generator)
+    end
+  end
   @doc """
   Builds a factory with the passed in factory_name and attrs
 

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -36,7 +36,7 @@ defmodule ExMachina do
     quote do
       @before_compile unquote(__MODULE__)
 
-      import ExMachina, only: [sequence: 1, sequence: 2, factory: 2]
+      import ExMachina, only: [sequence: 1, sequence: 2, machine: 2]
 
       def build(factory_name, attrs \\ %{}) do
         ExMachina.build(__MODULE__, factory_name, attrs)
@@ -132,11 +132,11 @@ defmodule ExMachina do
 
   ## Example
       # Will generate a user_factory function
-      factory :user do
+      machine :user do
         %{username: sequence("user")}
       end
   """
-  defmacro factory(name, do: generator) do
+  defmacro machine(name, do: generator) do
     quote bind_quoted: [
       name: Macro.escape(name, unquote: true),
       generator: Macro.escape(generator, unquote: true)

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -137,11 +137,14 @@ defmodule ExMachina do
       end
   """
   defmacro factory(name, do: generator) do
-    quote bind_quoted: [name: name, generator: generator] do
+    quote bind_quoted: [
+      name: Macro.escape(name, unquote: true),
+      generator: Macro.escape(generator, unquote: true)
+    ] do
       name = ExMachina.build_function_name(name)
-      generator = Macro.escape(generator)
+      body = generator
 
-      def unquote(name)(), do: unquote(generator)
+      def unquote(name)(), do: unquote(body)
     end
   end
   @doc """

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -137,9 +137,10 @@ defmodule ExMachina do
       end
   """
   defmacro factory(name, do: generator) do
-    name = build_function_name(name)
-    
-    quote do
+    quote bind_quoted: [name: name, generator: generator] do
+      name = ExMachina.build_function_name(name)
+      generator = Macro.escape(generator)
+
       def unquote(name)(), do: unquote(generator)
     end
   end
@@ -165,7 +166,7 @@ defmodule ExMachina do
     end
   end
 
-  defp build_function_name(factory_name) do
+  def build_function_name(factory_name) do
     factory_name
     |> Atom.to_string
     |> Kernel.<>("_factory")

--- a/lib/ex_machina/factory.ex
+++ b/lib/ex_machina/factory.ex
@@ -1,0 +1,37 @@
+defmodule ExMachina.Factory do
+  @moduledoc """
+  Define function/macros for grouping factories
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      @before_compile unquote(__MODULE__)
+
+      import unquote(__MODULE__)
+      use ExMachina
+
+      @factories []
+    end
+  end
+
+  defmacro __before_compile__(_opts) do
+    quote do
+      defmacro __using__(_opts) do
+        quote do
+          factories = unquote(Macro.escape(@factories))
+          IO.puts "Factories for #{unquote(__MODULE__)} -> #{inspect factories}"
+          for {name, generator} <- factories do
+            factory name, do: generator
+          end
+        end
+      end
+    end
+  end
+
+  defmacro machine(name, do: generator) do
+    quote do
+      @factories [{unquote(name), unquote(generator)} | @factories]
+      factory unquote(name), do: unquote(generator)
+    end
+  end
+end

--- a/lib/ex_machina/factory.ex
+++ b/lib/ex_machina/factory.ex
@@ -23,7 +23,7 @@ defmodule ExMachina.Factory do
           definitions = quote unquote: false do
             factories = @local_factories
             for {name, generator} <- factories do
-              factory unquote(name), do: unquote(generator)
+              machine unquote(name), do: unquote(generator)
             end
           end
 
@@ -33,13 +33,13 @@ defmodule ExMachina.Factory do
     end
   end
 
-  defmacro machine(name, do: generator) do
+  defmacro factory(name, do: generator) do
     quote bind_quoted: [
       name: Macro.escape(name, unquote: true),
       generator: Macro.escape(generator, unquote: true)
     ] do
       @factories [{name, generator} | @factories]
-      factory unquote(name), do: unquote(generator)
+      machine unquote(name), do: unquote(generator)
     end
   end
 end

--- a/lib/ex_machina/factory.ex
+++ b/lib/ex_machina/factory.ex
@@ -3,6 +3,7 @@ defmodule ExMachina.Factory do
   Define function/macros for grouping factories
   """
 
+  @doc false
   defmacro __using__(_opts) do
     quote do
       @before_compile unquote(__MODULE__)
@@ -14,12 +15,19 @@ defmodule ExMachina.Factory do
     end
   end
 
+  @doc """
+  Hook to define module's __using__ macro
+  """
   defmacro __before_compile__(_opts) do
     quote unquote: false do
       defmacro __using__(_opts) do
         quote do
           @local_factories unquote(Macro.escape(@factories))
 
+          # TODO: The definitions were wrapped inside a function and latter on evaluated
+          # because I couldn't find a way to bind_quoted que @factories attribute
+          # and access it. It seems that Elixir defines the bind_quoted in the context
+          # of __using__, then we cannot access it from the exported quoted expression
           definitions = quote unquote: false do
             factories = @local_factories
             for {name, generator} <- factories do
@@ -33,6 +41,9 @@ defmodule ExMachina.Factory do
     end
   end
 
+  @doc """
+  Create a local factory and register it to be exported by __using__
+  """
   defmacro factory(name, do: generator) do
     quote bind_quoted: [
       name: Macro.escape(name, unquote: true),

--- a/test/ex_machina/factory_test.exs
+++ b/test/ex_machina/factory_test.exs
@@ -1,0 +1,35 @@
+defmodule ExMachina.EnterpriseTest do
+  use ExUnit.Case
+
+  defmodule China do
+    use ExMachina.Factory
+
+    machine :iron do
+      %{iron: true}
+    end
+  end
+
+  defmodule Japan do
+    use ExMachina.Factory
+
+    machine :paper do
+      %{paper: true}
+    end
+  end
+
+  defmodule Company do
+    use ExMachina
+    use Japan
+    use China
+  end
+
+  test "simple factories should be able to build" do
+    assert Japan.build(:paper) == %{paper: true}
+    assert China.build(:iron) == %{iron: true}
+  end
+
+  test "`use Factory` should define __using__ with factories" do
+    assert Company.build(:paper) == %{paper: true}
+    assert Company.build(:iron) == %{iron: true}
+  end
+end

--- a/test/ex_machina/factory_test.exs
+++ b/test/ex_machina/factory_test.exs
@@ -13,7 +13,14 @@ defmodule ExMachina.EnterpriseTest do
     use ExMachina.Factory
 
     machine :paper do
-      %{paper: true}
+      %{
+        paper: true,
+        type: Japan.something()
+      }
+    end
+
+    def something do
+      "Something"
     end
   end
 
@@ -24,12 +31,12 @@ defmodule ExMachina.EnterpriseTest do
   end
 
   test "simple factories should be able to build" do
-    assert Japan.build(:paper) == %{paper: true}
+    assert Japan.build(:paper) == %{paper: true, type: "Something"}
     assert China.build(:iron) == %{iron: true}
   end
 
   test "`use Factory` should define __using__ with factories" do
-    assert Company.build(:paper) == %{paper: true}
+    assert Company.build(:paper) == %{paper: true, type: "Something"}
     assert Company.build(:iron) == %{iron: true}
   end
 end

--- a/test/ex_machina/factory_test.exs
+++ b/test/ex_machina/factory_test.exs
@@ -28,6 +28,13 @@ defmodule ExMachina.EnterpriseTest do
     use ExMachina
     use Japan
     use China
+
+    machine :compound do
+      %{
+        paper: build(:paper),
+        iron: build(:iron)
+      }
+    end
   end
 
   test "simple factories should be able to build" do
@@ -36,7 +43,11 @@ defmodule ExMachina.EnterpriseTest do
   end
 
   test "`use Factory` should define __using__ with factories" do
-    assert Company.build(:paper) == %{paper: true, type: "Something"}
-    assert Company.build(:iron) == %{iron: true}
+    paper = %{paper: true, type: "Something"}
+    iron = %{iron: true}
+
+    assert Company.build(:paper) == paper
+    assert Company.build(:iron) == iron
+    assert Company.build(:compound) == %{paper: paper, iron: iron}
   end
 end

--- a/test/ex_machina/factory_test.exs
+++ b/test/ex_machina/factory_test.exs
@@ -4,7 +4,7 @@ defmodule ExMachina.EnterpriseTest do
   defmodule China do
     use ExMachina.Factory
 
-    machine :iron do
+    factory :iron do
       %{iron: true}
     end
   end
@@ -12,7 +12,7 @@ defmodule ExMachina.EnterpriseTest do
   defmodule Japan do
     use ExMachina.Factory
 
-    machine :paper do
+    factory :paper do
       %{
         paper: true,
         type: Japan.something()

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -4,7 +4,7 @@ defmodule ExMachinaTest do
   defmodule Factory do
     use ExMachina
 
-    def user_factory do
+    factory :user do
       %{
         id: 3,
         name: "John Doe",
@@ -12,19 +12,19 @@ defmodule ExMachinaTest do
       }
     end
 
-    def email_factory do
+    factory :email do
       %{
         email: sequence(:email, &"me-#{&1}@foo.com")
       }
     end
 
-    def article_factory do
+    factory :article do
       %{
         title: sequence("Post Title")
       }
     end
 
-    def struct_factory do
+    factory :struct do
       %{
         __struct__: Foo.Bar
       }

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -29,6 +29,16 @@ defmodule ExMachinaTest do
         __struct__: Foo.Bar
       }
     end
+
+    factory :comment do
+      %{
+        text: "Maybe factory_for is better"
+      }
+    end
+  end
+
+  test "factory/2 creates a function for build" do
+    assert "Maybe factory_for is better" = Factory.build(:comment).text
   end
 
   test "sequence/2 sequences a value" do

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -4,7 +4,7 @@ defmodule ExMachinaTest do
   defmodule Factory do
     use ExMachina
 
-    factory :user do
+    machine :user do
       %{
         id: 3,
         name: "John Doe",
@@ -12,25 +12,25 @@ defmodule ExMachinaTest do
       }
     end
 
-    factory :email do
+    machine :email do
       %{
         email: sequence(:email, &"me-#{&1}@foo.com")
       }
     end
 
-    factory :article do
+    machine :article do
       %{
         title: sequence("Post Title")
       }
     end
 
-    factory :struct do
+    machine :struct do
       %{
         __struct__: Foo.Bar
       }
     end
 
-    factory :comment do
+    machine :comment do
       %{
         text: "Maybe factory_for is better"
       }


### PR DESCRIPTION
I've written a simple DSL to allow defining simple factories with `machine/2` and for separating factories in different modules with `ExMachina.Factory` and `factory/2`, i. e.

```elixir
def SimpleFactory do
  use ExMachina

  machine :user do
    %{ name: "John", id: sequence("user-") }
  end
end
```

```elixir
def FactoryA do
  use ExMachina.Factory

  factory :iron do
    %{ iron: true }
  end
end

def FactoryB do
  use ExMachina.Factory

  factory :copper do
    %{ copper: true }
  end
end

def Company do
  use ExMachina # Needed to define build and import machine

  use FactoryA
  use FactoryB

  machine :compound do
    %{ iron: build(:iron), copper: build(:copper) }
  end
end

# Local machines are defined also
FactoryB.build(:copper)
FactoryA.build(:iron)
Company.build(:compound)
```

The only point which I don't know how to handle is when you want to use local functions, with the actual solution you have to provide the function's full name in order to allow usage in factories.

```elixir
def FactoryA do
  use ExMachina.Factory

  factory :paper do
    %{
      # Works because `sequence` is available here and when importing - if the user has imported ExMachina
      type: sequence("type-"),
      # We cannot use `color()` because when imported I'll not have `color/0` on target
      color: FactoryA.color()
    }
  end

  def color, do: "Black"
end
```

That is everything I've done so far while learning macros, maybe there is something wrong. Besides that, it was a wonderful experience, I've learned a lot of things. #first-contribution 😄