### PR TITLE
Fixes issue with passing maps for embeds to params_for/2

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -202,7 +202,7 @@ defmodule ExMachina.Ecto do
 
   defp handle_embed(original_embed, record, embed_name) do
     case original_embed do
-      %{__struct__: _} ->
+      %{} ->
         embed = recursively_strip(original_embed)
         Map.put(record, embed_name, embed)
       list when is_list(list) ->

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -111,6 +111,12 @@ defmodule ExMachina.EctoTest do
     assert comment_params.author == %{name: "Author", salary: 1.0}
   end
 
+  test "params_for/2 accepts maps for embeds" do
+    author = %{name: "Author", salary: 1.0}
+    comment_params = TestFactory.params_for(:comment_with_embedded_assocs, author: author)
+    assert comment_params.author == %{name: "Author", salary: 1.0}
+  end
+
   test "params_for/2 converts embeds_many into a list of maps" do
     links = [%ExMachina.Link{url: "https://thoughtbot.com", rating: 5}, %ExMachina.Link{url: "https://github.com", rating: 4}]
     comment_params = TestFactory.params_for(:comment_with_embedded_assocs, links: links)


### PR DESCRIPTION
I just tried out using the master branch for embeds in `params_for/2` and encountered unexpected behavior. In my current project I already have calls like `prams_for(:product, weight: %{value: 10, unit: "kg"})` and this fails in `recursively_strip/1`.

This PR fixes the issue.