### PR TITLE
Add option to import factories

### DIFF
--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -33,16 +33,15 @@ defmodule ExMachina do
   def start(_type, _args), do: ExMachina.Sequence.start_link
 
   defmacro __using__(opts) do
+    imported_factories = Keyword.get(opts, :import, [])
+
     quote do
       @before_compile unquote(__MODULE__)
-
-      imported_factories = unquote(opts) || []
-      @imported_factories Keyword.get(imported_factories, :import, [])
 
       import ExMachina, only: [sequence: 1, sequence: 2]
 
       def builder(factory_name, attrs \\ %{}) do
-        ExMachina.builder(__MODULE__, @imported_factories, factory_name, attrs)
+        ExMachina.builder(__MODULE__, unquote(imported_factories), factory_name, attrs)
       end
 
       def build(factory_name, attrs \\ %{}) do

--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -48,11 +48,11 @@ defmodule ExMachina do
         ExMachina.build(__MODULE__, factory_name, attrs)
       end
       def build_pair(factory_name, attrs \\ %{}) do
-        ExMachina.build_pair(__MODULE__, @imported_factories, factory_name, attrs)
+        ExMachina.build_pair(__MODULE__, factory_name, attrs)
       end
 
       def build_list(number_of_records, factory_name, attrs \\ %{}) do
-        ExMachina.build_list(__MODULE__, @imported_factories, number_of_records, factory_name, attrs)
+        ExMachina.build_list(__MODULE__, number_of_records, factory_name, attrs)
       end
 
       @spec create(any) :: no_return
@@ -231,8 +231,8 @@ defmodule ExMachina do
   @callback build_pair(factory_name :: atom, attrs :: keyword | map) :: list
 
   @doc false
-  def build_pair(module, fallbacks, factory_name, attrs \\ %{}) do
-    ExMachina.build_list(module, fallbacks, 2, factory_name, attrs)
+  def build_pair(module, factory_name, attrs \\ %{}) do
+    ExMachina.build_list(module, 2, factory_name, attrs)
   end
 
   @doc """
@@ -246,7 +246,7 @@ defmodule ExMachina do
   @callback build_list(number_of_records :: integer, factory_name :: atom, attrs :: keyword | map) :: list
 
   @doc false
-  def build_list(module, fallbacks, number_of_records, factory_name, attrs \\ %{}) do
+  def build_list(module, number_of_records, factory_name, attrs \\ %{}) do
     Stream.repeatedly(fn ->
       ExMachina.build(module, factory_name, attrs)
     end)

--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -14,9 +14,12 @@ defmodule ExMachina.Ecto do
   """
   defmacro __using__(opts) do
     verify_ecto_dep()
+
+    imported_factories = Keyword.get(opts, :import, [])
+
     if repo = Keyword.get(opts, :repo) do
       quote do
-        use ExMachina
+        use ExMachina, import: unquote(imported_factories)
         use ExMachina.EctoStrategy, repo: unquote(repo)
 
         def params_for(factory_name, attrs \\ %{}) do

--- a/test/ex_machina/ecto_strategy_test.exs
+++ b/test/ex_machina/ecto_strategy_test.exs
@@ -5,6 +5,7 @@ defmodule ExMachina.EctoStrategyTest do
   alias ExMachina.User
 
   defmodule FactoryWithNoRepo do
+    use ExMachina
     use ExMachina.EctoStrategy
 
     def whatever_factory do

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -232,4 +232,23 @@ defmodule ExMachina.EctoTest do
   defp has_association_in_schema?(model, association_name) do
     Enum.member?(model.__schema__(:associations), association_name)
   end
+
+  describe "factory importing" do
+    defmodule FactoryX do
+      use ExMachina.Ecto, repo: ExMachina.TestRepo, import: [TestFactory]
+
+      def custom_user_factory do
+        %ExMachina.User{
+          name: "John Doe",
+          admin: false,
+          articles: []
+        }
+      end
+    end
+
+    test "insert/2 will try imported factories if not found" do
+      assert %User{} = FactoryX.insert(:user)
+      assert %User{} = FactoryX.insert(:custom_user)
+    end
+  end
 end

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -121,31 +121,33 @@ defmodule ExMachinaTest do
     end
   end
 
-  defmodule FactoryA do
-    use ExMachina
+  describe "factory importing" do
+    defmodule FactoryA do
+      use ExMachina
 
-    def article_factory do
-      %{
-        title: sequence(:factory_article, &"Post Title#{&1}")
-      }
+      def article_factory do
+        %{
+          title: sequence(:factory_article, &"Post Title#{&1}")
+        }
+      end
     end
-  end
 
-  defmodule FactoryB do
-    def comment_factory do
-      %{
-        user: "New user",
-        comment: "Something interesting"
-      }
+    defmodule FactoryB do
+      def comment_factory do
+        %{
+          user: "New user",
+          comment: "Something interesting"
+        }
+      end
     end
-  end
 
-  defmodule FactoryC do
-    use ExMachina, import: [FactoryA, FactoryB]
-  end
+    defmodule FactoryC do
+      use ExMachina, import: [FactoryA, FactoryB]
+    end
 
-  test "build/2 will try imported factories if not found" do
-    assert "Something interesting" == FactoryC.build(:comment).comment
-    assert "Post Title0" == FactoryC.build(:article).title
+    test "build/2 will try imported factories if not found" do
+      assert "Something interesting" == FactoryC.build(:comment).comment
+      assert "Post Title0" == FactoryC.build(:article).title
+    end
   end
 end

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -120,4 +120,34 @@ defmodule ExMachinaTest do
       Factory.create_list(3, :user, admin: true)
     end
   end
+
+  defmodule FactoryA do
+    use ExMachina
+
+    def article_factory do
+      %{
+        title: sequence(:factory_article, &"Post Title#{&1}")
+      }
+    end
+  end
+
+  defmodule FactoryB do
+    use ExMachina
+
+    def comment_factory do
+      %{
+        user: sequence(:user, &"User ##{&1}"),
+        comment: "Something interesting"
+      }
+    end
+  end
+
+  defmodule FactoryC do
+    use ExMachina, import: [FactoryA, FactoryB]
+  end
+
+  test "new_build/2 will try imported factories if not found" do
+    assert "Something interesting" == FactoryC.new_build(:comment).comment
+    assert "Post Title0" == FactoryC.new_build(:article).title
+  end
 end

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -132,11 +132,9 @@ defmodule ExMachinaTest do
   end
 
   defmodule FactoryB do
-    use ExMachina
-
     def comment_factory do
       %{
-        user: sequence(:user, &"User ##{&1}"),
+        user: "New user",
         comment: "Something interesting"
       }
     end
@@ -146,8 +144,8 @@ defmodule ExMachinaTest do
     use ExMachina, import: [FactoryA, FactoryB]
   end
 
-  test "new_build/2 will try imported factories if not found" do
-    assert "Something interesting" == FactoryC.new_build(:comment).comment
-    assert "Post Title0" == FactoryC.new_build(:article).title
+  test "build/2 will try imported factories if not found" do
+    assert "Something interesting" == FactoryC.build(:comment).comment
+    assert "Post Title0" == FactoryC.build(:article).title
   end
 end


### PR DESCRIPTION
After discussing in #228 about how to import factories, I've added an option to `ExMachina.__using__/1` to use other factories as fallbacks. Now you can have a factory that imports another and uses its factories.

```elixir
defmodule FactoryA do
    use ExMachina

    def article_factory do
    %{
        title: sequence(:factory_article, &"Post Title#{&1}")
    }
    end
end

defmodule FactoryB do
    def comment_factory do
    %{
        user: "New user",
        comment: "Something interesting"
    }
    end
end

defmodule FactoryC do
    use ExMachina, import: [FactoryA, FactoryB]
end

FactoryC.build(:comment) == %{ user: "New user", comment: "Something interesting" }
FactoryC.build(:article) == %{ title: "Post Title0" }
```
The only point which I haven't liked much is when using Ecto in which I have to pass the imported factories to ExMachina.Ecto and then to ExMachina. I think that requiring ExMachina before using every strategy is a better approach.

@ericmj Is there any improvement that I could do?