### PR TITLE
Support structs in string_params_for/2

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -315,6 +315,9 @@ defmodule ExMachina.Ecto do
   defp convert_atom_keys_to_strings(values) when is_list(values) do
     Enum.map(values, &convert_atom_keys_to_strings/1)
   end
+  defp convert_atom_keys_to_strings(%{__struct__: _} = record) when is_map(record) do
+    Map.from_struct(record) |> convert_atom_keys_to_strings()
+  end
   defp convert_atom_keys_to_strings(record) when is_map(record) do
     Enum.reduce record, Map.new, fn({key, value}, acc) ->
       Map.put(acc, to_string(key), convert_atom_keys_to_strings(value))

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -142,6 +142,14 @@ defmodule ExMachina.EctoTest do
     }
   end
 
+  test "string_params_for/2 converts structs into maps with strings as keys" do
+    net_worth = %Money{amount: 2_000}
+
+    user_params = TestFactory.string_params_for(:user, net_worth: net_worth)
+
+    assert user_params["net_worth"] == %{"amount" => 2_000}
+  end
+
   test "string_params_for/2 converts has_one association into map with strings as keys" do
     article = TestFactory.build(:article)
 

--- a/test/support/models/money.ex
+++ b/test/support/models/money.ex
@@ -1,0 +1,3 @@
+defmodule Money do
+  defstruct amount: 0
+end


### PR DESCRIPTION
Summary
=======

`string_params_for/2` currently fails when a struct is passed for a
field. The error comes when a function from the enumerable protocol is
called on the struct (assuming it's a plain map). So the following
example would fail,

```elixir
Factory.string_params_for(:model, some_field: %SomeStruct{key: value})
```

The behavior of `string_params_for/2` with a struct should be to convert
it into a plain map with strings as keys. So in the example above, we
would expect the result from `string_params_for/2` to include
`%{"some_field" => %{"key" => value}}`

This commit does this by using `Map.from_struct/1` to turn the struct
into plain map before continuing with the process of converting the
atoms into strings.

I believe this takes care of https://github.com/thoughtbot/ex_machina/issues/243