### PR TITLE
add nil_params_for/2 to aid in writing @invalid_attrs

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -156,7 +156,7 @@ defmodule ExMachina.Ecto do
   def nil_params_for(module, factory_name) do
     module
     |> params_for(factory_name, %{})
-    |> Enum.map( fn{k, _v} -> {k, nil} end )
+    |> Enum.map(fn{k, _v} -> {k, nil} end)
     |> Map.new
   end
 

--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -27,6 +27,10 @@ defmodule ExMachina.Ecto do
           ExMachina.Ecto.string_params_for(__MODULE__, factory_name, attrs)
         end
 
+        def nil_params_for(factory_name) do
+          ExMachina.Ecto.nil_params_for(__MODULE__, factory_name)
+        end
+
         def params_with_assocs(factory_name, attrs \\ %{}) do
           ExMachina.Ecto.params_with_assocs(__MODULE__, factory_name, attrs)
         end
@@ -132,6 +136,28 @@ defmodule ExMachina.Ecto do
     module
     |> params_for(factory_name, attrs)
     |> convert_atom_keys_to_strings
+  end
+
+  @doc """
+  Similar to `c:params_for/2` but converts all values to nil in returned map.
+
+  ## Example
+
+      def user_factory do
+        %MyApp.User{name: "John Doe", admin: false}
+      end
+
+      # Returns %{name: => nil, admin: => nil}
+      nil_params_for(:user)
+  """
+  @callback nil_params_for(factory_name :: atom) :: %{optional(atom) => any}
+
+  @doc false
+  def nil_params_for(module, factory_name) do
+    module
+    |> params_for(factory_name, %{})
+    |> Enum.map( fn{k, _v} -> {k, nil} end )
+    |> Map.new
   end
 
   @doc """

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -185,6 +185,14 @@ defmodule ExMachina.EctoTest do
     ]
   end
 
+  test "nil_params_for/2 produces maps similar to ones built with params_for/2, but the values are nil" do
+    assert TestFactory.nil_params_for(:user) == %{
+      name: nil,
+      admin: nil,
+      articles: nil
+    }
+  end
+
   test "params_with_assocs/2 inserts belongs_tos that are set by the factory" do
     assert has_association_in_schema?(ExMachina.Article, :editor)
 


### PR DESCRIPTION
If you follow the way the phoenix generators make tests you will see the use of @invalid_attrs where a map lists all of the keys but where all the values are nil. This helper allows for quickly replacing the the current use of @invalid_attrs.