### PR TITLE
Handle nil values for has_one associations

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -216,6 +216,9 @@ defmodule ExMachina.Ecto do
         assoc = recursively_strip(original_assoc)
         Map.put(record, association_name, assoc)
 
+      nil ->
+        Map.put(record, association_name, nil)
+
       list when is_list(list) ->
         has_many_assoc = Enum.map(original_assoc, &recursively_strip/1)
         Map.put(record, association_name, has_many_assoc)

--- a/test/support/test_factory.ex
+++ b/test/support/test_factory.ex
@@ -13,6 +13,7 @@ defmodule ExMachina.TestFactory do
       name: "John Doe",
       admin: false,
       articles: [],
+      best_article: nil,
     }
   end
 


### PR DESCRIPTION
The has_one association allows for the referenced value to be nil.

ExMachina by default sets such fields to `%Ecto.Association.NotLoaded{}` when the field Is not mentioned in the factory definition. However, setting the field to nil explicitly in the factory definition caused a CaseClauseError in ExMachina.Ecto.handle_assoc.