### PR TITLE
Update underscore/1 to support Elixir 1.6's regex

### DIFF
--- a/lib/ex_machina/strategy.ex
+++ b/lib/ex_machina/strategy.ex
@@ -137,10 +137,8 @@ defmodule ExMachina.Strategy do
     struct_name
     |> Module.split
     |> List.last
-    |> underscore
+    |> Macro.underscore
     |> String.downcase
     |> String.to_atom
   end
-
-  defp underscore(name), do: Regex.replace(~r/(?<!^)(?=[A-Z])/, name, "_")
 end

--- a/lib/ex_machina/strategy.ex
+++ b/lib/ex_machina/strategy.ex
@@ -142,9 +142,5 @@ defmodule ExMachina.Strategy do
     |> String.to_atom
   end
 
-  defp underscore(name) do
-    ~r/(?=[A-Z])/
-    |> Regex.split(name)
-    |> Enum.join("_")
-  end
+  defp underscore(name), do: Regex.replace(~r/(?<!^)(?=[A-Z])/, name, "_")
 end


### PR DESCRIPTION
`Regex.split/3`'s behavior was [changed in Elixir 1.6]( https://github.com/elixir-lang/elixir/issues/7385) and caused `ExMachina.Strategy.underscore/1` to return an extra underscore and broke all factory names that are generated by `ExMachina.Strategy.name_from_struct/1`.

This PR does ~2 things~ 1 thing:
- ~Fixes the regex inside `ExMachina.Strategy.underscore/1` to do negative lookbehind for a start of line.~
- ~Use a single `Regex.replace/4` instead of `Regex.split/3` + `Enum.join/2` which, [according to Jose Valim, is equivalent](https://github.com/elixir-lang/elixir/issues/7385#issuecomment-367969050).~
- Use [`Macro.underscore/1`](https://hexdocs.pm/elixir/Macro.html#underscore/1) instead of `Regex.split/3` + `Enum.join/2` to convert module name to snake case. (Thanks @vernomcrp for the suggestion!)

# Before

## Elixir 1.5.3 (success)

```elixir
$ elixir --version
Erlang/OTP 20 [erts-9.2.1] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:10] [hipe] [kernel-poll:false]

Elixir 1.5.3

$ mix test
The database for ExMachina.TestRepo has been dropped
The database for ExMachina.TestRepo has been created
................................................................

Finished in 0.3 seconds
64 tests, 0 failures

Randomized with seed 941966
```

## Elixir 1.6.2 (failed)

```elixir
$ elixir --version
Erlang/OTP 20 [erts-9.2.1] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:10] [hipe] [kernel-poll:false]

Elixir 1.6.2 (compiled with OTP 20)

$ mix test
The database for ExMachina.TestRepo has been dropped
The database for ExMachina.TestRepo has been created


  1) test name_from_struct returns the factory name based on passed in struct (ExMachina.StrategyTest)
     test/ex_machina/strategy_test.exs:23
     Assertion with == failed
     code:  assert ExMachina.Strategy.name_from_struct(%{__struct__: User}) == :user
     left:  :_user
     right: :user
     stacktrace:
       test/ex_machina/strategy_test.exs:24: (test)

...............................................................

Finished in 0.3 seconds
64 tests, 1 failure

Randomized with seed 568658
```

# After 

## Elixir 1.5.3 (success)

```elixir
$ elixir --version
Erlang/OTP 20 [erts-9.2.1] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:10] [hipe] [kernel-poll:false]

Elixir 1.5.3

$ mix test
The database for ExMachina.TestRepo has been dropped
The database for ExMachina.TestRepo has been created
................................................................

Finished in 0.3 seconds
64 tests, 0 failures

Randomized with seed 801432
```

## Elixir 1.6.2 (success)

```elixir
$ elixir --version
Erlang/OTP 20 [erts-9.2.1] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:10] [hipe] [kernel-poll:false]

Elixir 1.6.2 (compiled with OTP 20)

$ mix test
Compiling 3 files (.ex)
The database for ExMachina.TestRepo has been dropped
The database for ExMachina.TestRepo has been created
................................................................

Finished in 0.5 seconds
64 tests, 0 failures

Randomized with seed 824888
```