### PR TITLE
Bump version to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ complete changelog, see the git history for each version via the version links.
 
 [hex package page]: https://hex.pm/packages/ex_machina
 
+## [2.2.0]
+
+### Added
+
+- Adds support for using lists in sequences ([#227]).
+
+### Fixed
+
+- Elixir 1.6.x changed the behavior of `Regex.split/3` which caused factory
+  names to break. Added a fix in ([#275]).
+
+[2.2.0]: https://github.com/thoughtbot/ex_machina/compare/v2.1.0...v2.2.0
+[#227]: https://github.com/thoughtbot/ex_machina/pull/227
+[#275]: https://github.com/thoughtbot/ex_machina/pull/275
+
 ## [2.1.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In `mix.exs`, add the ExMachina dependency:
 def deps do
   # Get the latest from hex.pm. Works with Ecto 2.0
   [
-    {:ex_machina, "~> 2.1"},
+    {:ex_machina, "~> 2.2"},
   ]
 end
 ```
@@ -43,7 +43,7 @@ In `mix.exs`, add the ExMachina dependency:
 ```elixir
 def deps do
   [
-    {:ex_machina, "~> 2.1", only: :test},
+    {:ex_machina, "~> 2.2", only: :test},
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ExMachina.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/thoughtbot/ex_machina"
-  @version "2.1.0"
+  @version "2.2.0"
 
   def project() do
     [


### PR DESCRIPTION
Bump version to 2.2.0. Notable changes include,

- Support for lists in sequences (PR #227)
- Using `Macro.underscore/1` so that factory names don't break in elixir
1.6 (PR #275)