### PR TITLE
Bump Elixir Requirement to >= 1.4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule ExMachina.Mixfile do
     [
       app: :ex_machina,
       version: @version,
-      elixir: "~> 1.2",
+      elixir: ">= 1.4.0",
       description: "A factory library by the creators of FactoryGirl",
       source_url: @project_url,
       homepage_url: @project_url,


### PR DESCRIPTION
Because we use `List.pop_at` from #227, we require the project to run with Elixir 1.4.0 or higher. This reports ex_machina correctly. [List.pop_at was introduced in Elixir 1.4.0
](https://github.com/elixir-lang/elixir/blob/v1.4/CHANGELOG.md)