### PR TITLE
Add list to typespec for sequence/2

### DIFF
--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -142,7 +142,7 @@ defmodule ExMachina do
       end
   """
 
-  @spec sequence(any, (integer -> any)) :: any
+  @spec sequence(any, (integer -> any) | nonempty_list) :: any
   def sequence(name, formatter), do: ExMachina.Sequence.next(name, formatter)
 
   @doc """


### PR DESCRIPTION
sequence/2 can receive a list as second argument, but right now the typespec does not reflect that.