### PR TITLE
Remove obsolete `fields_for/2` function

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -34,10 +34,6 @@ defmodule ExMachina.Ecto do
         def string_params_with_assocs(factory_name, attrs \\ %{}) do
           ExMachina.Ecto.string_params_with_assocs(__MODULE__, factory_name, attrs)
         end
-
-        def fields_for(factory_name, attrs \\ %{}) do
-          raise "fields_for/2 has been renamed to params_for/2."
-        end
       end
     else
       raise ArgumentError,


### PR DESCRIPTION
Fixes #157

Since version 1.0.0, when users of ex_machina try to call the deprecated `fields_for/2` function, it raises an exception. This doesn't seem to provide any benefit. If instead it's removed, calls to it will fail at compile time. But if it stays in, calls will fail at runtime, possibly in production.

This PR solves the Dialyzer issue and it provides a better solution for dealing with the obsolete function.