### PR TITLE
Update Readme to clarify support for ecto 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In `mix.exs`, add the ExMachina dependency:
 
 ```elixir
 def deps do
-  # Get the latest from hex.pm. Works with Ecto 2.0
+  # Get the latest from hex.pm. Works with Ecto 3.0
   [
     {:ex_machina, "~> 2.2"},
   ]


### PR DESCRIPTION
Looks like 3.0 is supported as of https://github.com/thoughtbot/ex_machina/pull/301