### PR TITLE
Allow more control over factory definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,53 @@ string_params_for(:comment, attrs)
 string_params_with_assocs(:comment, attrs)
 ```
 
+## Full control of factory
+
+By default, ExMachina will merge the attributes you pass into build/insert into
+your factory. But if you want full control of your attributes, you can define
+your factory as accepting one argument, the attributes being passed into your
+factory.
+
+```elixir
+def custom_article_factory(attrs) do
+  title = Map.get(attrs, :title, "default title")
+
+  article = %Article{
+    author: "John Doe",
+    title: title
+  }
+
+  # merge attributes at the end to emulate ExMachina default behavior
+  merge_attributes(article, attrs)
+end
+```
+
+**NOTE** that in this case ExMachina will _not_ merge the attributes into your
+factory, and you will have to do this on your own if desired.
+
+### Non-map factories
+
+Because you have full control of the factory when defining it with one argument,
+you can build factories that are neither maps nor structs.
+
+```elixir
+# factory definition
+def room_number_factory(attrs) do
+  %{floor: floor_number} = attrs
+  sequence(:room_number, &"#{floor_number}0#{&1}")
+end
+
+# example usage
+build(:room_number, floor: 5)
+# => "500"
+
+build(:room_number, floor: 5)
+# => "501"
+```
+
+**NOTE** that you cannot use non-map factories with Ecto. So you cannot
+`insert(:room_number)`.
+
 ## Usage in a test
 
 ```elixir

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -29,6 +29,24 @@ defmodule ExMachinaTest do
         __struct__: Foo.Bar
       }
     end
+
+    def comment_factory(attrs) do
+      %{name: name} = attrs
+
+      username = sequence(:username, &"#{name}-#{&1}")
+
+      comment = %{
+        author: "#{name} Doe",
+        username: username
+      }
+
+      merge_attributes(comment, attrs)
+    end
+
+    def room_number_factory(attrs) do
+      %{floor: floor_number} = attrs
+      sequence(:room_number, &"#{floor_number}0#{&1}")
+    end
   end
 
   test "sequence/2 sequences a value" do
@@ -75,6 +93,19 @@ defmodule ExMachinaTest do
     assert_raise KeyError, fn ->
       Factory.build(:struct, doesnt_exist: true)
     end
+  end
+
+  test "build/2 allows factories to have full control of provided arguments" do
+    assert Factory.build(:comment, name: "James") == %{
+             author: "James Doe",
+             username: "James-0",
+             name: "James"
+           }
+  end
+
+  test "build/2 allows custom (non-map) factories to be built" do
+    assert Factory.build(:room_number, floor: 5) == "500"
+    assert Factory.build(:room_number, floor: 5) == "501"
   end
 
   test "build_pair/2 builds 2 factories" do


### PR DESCRIPTION
Closes: https://github.com/thoughtbot/ex_machina/issues/309, https://github.com/thoughtbot/ex_machina/issues/272, https://github.com/thoughtbot/ex_machina/issues/271

Description
-----------

Currently `build(:user)` will grab the struct/map defined in `user_factory/0` and merge any attributes passed into it via `struct!/2` or `Map.merge/2`. 

It would be nice to allow users to have more control of factories if they want to, while maintaining the ease of use for the majority of cases. It seems this can be done by allowing users to change the `user_factory/0` to a factory that takes in the attributes being passed in.

We can do so by checking if they have defined a factory with `/1` arity (meaning they allow parameters to be passed).

Example
---------

Let's take a look at a scenario where this might be wanted:

```elixir
def user_factory do
  name = "John"
  email = sequence(:email, &"#{name}-#{&1}@foo.com")

  %User{
    name: name,
    email: email,
    age: 20
  }
end

build(:user)
# => %User{name: "John", email: "John-0@foo.com", age: 20}

build(:user, name: "James")
# => %User{name: "James", email: "John-0@foo.com", age: 20}
```

As we can see the issue is that since we derive the `email` from the `name`, the email has the old name in it, even when we pass "James" as the name. It would be nice to be able to get the `name` from the attributes _before_ we create the email.

So we could define this instead,

```elixir
def user_factory(attrs) do
  name = Map.get(attrs, :name, "John")
  email = sequence(:email, &"#{name}-#{&1}@foo.com")

  user = %User{
    name: name,
    email: email,
    age: 20
  }

  merge_attributes(user, attrs)
end

build(:user)
# => %User{name: "John", email: "John-0@foo.com", age: 20}

build(:user, name: "James", age: 30)
# => %User{name: "James", email: "James-0@foo.com", age: 30}
```

Note the inclusion of `merge_attributes/2` in our example above. We need that so that `age` gets properly overridden from `20` to `30`.

The `merge_attributes/2` function is a new function we expose to make it easier for users to merge attributes regardless of whether it is a struct or a map. It essentially delegates to `struct!/2` or `Map.merge/2`.

Non-map factories
-----------------

Because it provides full control over the factory, we can also now define non-map factories.

```elixir
def room_number_factory(_) do
  sequence(:room_number, &"50#{&1}")
end

build(:room_number)
# => "500"
```