### PR TITLE
Use Decimal.from_float/1 instead of Decimal.new/1

### DIFF
--- a/test/ex_machina/ecto_strategy_test.exs
+++ b/test/ex_machina/ecto_strategy_test.exs
@@ -72,9 +72,9 @@ defmodule ExMachina.EctoStrategyTest do
       )
 
     assert comment.author.name == author.name
-    assert comment.author.salary == Decimal.new(author.salary)
+    assert comment.author.salary == Decimal.from_float(author.salary)
     assert List.first(comment.links).url == link.url
-    assert List.first(comment.links).rating == Decimal.new(link.rating)
+    assert List.first(comment.links).rating == Decimal.from_float(link.rating)
   end
 
   test "insert/1 ignores virtual fields" do


### PR DESCRIPTION
`Decimal.new/1` was throwing a deprecation warning,

> passing float to Decimal.new/1 is deprecated, use Decimal.from_float/1 instead

We update the appropriate tests to use `Decimal.from_float/1`.