### PR TITLE
Fix indentation for doc example

### DIFF
--- a/lib/ex_machina.ex
+++ b/lib/ex_machina.ex
@@ -227,16 +227,16 @@ defmodule ExMachina do
 
   ## Example
 
-    # custom factory
-    def article_factory(attrs) do
-      title = Map.get(attrs, :title, "default title")
+      # custom factory
+      def article_factory(attrs) do
+        title = Map.get(attrs, :title, "default title")
 
-      article = %Article{
-        title: title
-      }
+        article = %Article{
+          title: title
+        }
 
-      merge_attributes(article, attrs)
-    end
+        merge_attributes(article, attrs)
+      end
 
   Note that when trying to merge attributes into a struct, this function will
   raise if one of the attributes is not defined in the struct.


### PR DESCRIPTION
Hey guys, just a simple indentation adjust in the documentation for `merge_attributes/2` function.

Before:

![before](https://user-images.githubusercontent.com/2160392/55674347-e65b0780-5889-11e9-82ee-239a179abae2.png)


After:

![after](https://user-images.githubusercontent.com/2160392/55674343-dfcc9000-5889-11e9-8874-fcd7c215db76.png)

