### PR TITLE
Allow ExMachina.Ecto to be used without the :repo option

### DIFF
--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -15,34 +15,25 @@ defmodule ExMachina.Ecto do
   defmacro __using__(opts) do
     verify_ecto_dep()
 
-    if repo = Keyword.get(opts, :repo) do
-      quote do
-        use ExMachina
-        use ExMachina.EctoStrategy, repo: unquote(repo)
+    quote do
+      use ExMachina
+      use ExMachina.EctoStrategy, repo: unquote(Keyword.get(opts, :repo))
 
-        def params_for(factory_name, attrs \\ %{}) do
-          ExMachina.Ecto.params_for(__MODULE__, factory_name, attrs)
-        end
-
-        def string_params_for(factory_name, attrs \\ %{}) do
-          ExMachina.Ecto.string_params_for(__MODULE__, factory_name, attrs)
-        end
-
-        def params_with_assocs(factory_name, attrs \\ %{}) do
-          ExMachina.Ecto.params_with_assocs(__MODULE__, factory_name, attrs)
-        end
-
-        def string_params_with_assocs(factory_name, attrs \\ %{}) do
-          ExMachina.Ecto.string_params_with_assocs(__MODULE__, factory_name, attrs)
-        end
+      def params_for(factory_name, attrs \\ %{}) do
+        ExMachina.Ecto.params_for(__MODULE__, factory_name, attrs)
       end
-    else
-      raise ArgumentError,
-            """
-            expected :repo to be given as an option. Example:
 
-            use ExMachina.Ecto, repo: MyApp.Repo
-            """
+      def string_params_for(factory_name, attrs \\ %{}) do
+        ExMachina.Ecto.string_params_for(__MODULE__, factory_name, attrs)
+      end
+
+      def params_with_assocs(factory_name, attrs \\ %{}) do
+        ExMachina.Ecto.params_with_assocs(__MODULE__, factory_name, attrs)
+      end
+
+      def string_params_with_assocs(factory_name, attrs \\ %{}) do
+        ExMachina.Ecto.string_params_with_assocs(__MODULE__, factory_name, attrs)
+      end
     end
   end
 

--- a/lib/ex_machina/ecto_strategy.ex
+++ b/lib/ex_machina/ecto_strategy.ex
@@ -12,6 +12,14 @@ defmodule ExMachina.EctoStrategy do
      #{inspect(record, limit: :infinity)}"
   end
 
+  def handle_insert(_, %{repo: nil}) do
+    raise """
+    insert/1 is not available unless you provide the :repo option. Example:
+
+    use ExMachina.Ecto, repo: MyApp.Repo
+    """
+  end
+
   def handle_insert(%{__meta__: %{__struct__: Ecto.Schema.Metadata}} = record, %{repo: repo}) do
     record
     |> cast

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -4,7 +4,7 @@ defmodule ExMachina.EctoTest do
   alias ExMachina.TestFactory
   alias ExMachina.User
 
-  test "insert raises helpful error message if no repo was provided" do
+  test "insert, insert_pair and insert_list raise helpful error messages if no repo was provided" do
     message = """
     insert/1 is not available unless you provide the :repo option. Example:
 
@@ -21,6 +21,14 @@ defmodule ExMachina.EctoTest do
 
     assert_raise RuntimeError, message, fn ->
       EctoWithNoRepoFactory.insert(:user)
+    end
+
+    assert_raise RuntimeError, message, fn ->
+      EctoWithNoRepoFactory.insert_pair(:user)
+    end
+
+    assert_raise RuntimeError, message, fn ->
+      EctoWithNoRepoFactory.insert_list(3, :user)
     end
   end
 

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -4,31 +4,48 @@ defmodule ExMachina.EctoTest do
   alias ExMachina.TestFactory
   alias ExMachina.User
 
-  test "insert, insert_pair and insert_list raise helpful error messages if no repo was provided" do
-    message = """
-    insert/1 is not available unless you provide the :repo option. Example:
-
-    use ExMachina.Ecto, repo: MyApp.Repo
-    """
-
-    defmodule EctoWithNoRepoFactory do
+  describe "when the :repo option is not provided" do
+    defmodule NoRepoTestFactory do
       use ExMachina.Ecto
 
       def user_factory do
-        %ExMachina.User{}
+        %ExMachina.User{
+          name: "John Doe",
+          admin: false
+        }
       end
     end
 
-    assert_raise RuntimeError, message, fn ->
-      EctoWithNoRepoFactory.insert(:user)
+    test "insert, insert_pair and insert_list raise helpful error messages if no repo was provided" do
+      message = """
+      insert/1 is not available unless you provide the :repo option. Example:
+
+      use ExMachina.Ecto, repo: MyApp.Repo
+      """
+
+      assert_raise RuntimeError, message, fn ->
+        NoRepoTestFactory.insert(:user)
+      end
+
+      assert_raise RuntimeError, message, fn ->
+        NoRepoTestFactory.insert_pair(:user)
+      end
+
+      assert_raise RuntimeError, message, fn ->
+        NoRepoTestFactory.insert_list(3, :user)
+      end
     end
 
-    assert_raise RuntimeError, message, fn ->
-      EctoWithNoRepoFactory.insert_pair(:user)
+    test "params_for/1 still works as expected" do
+      user_params = NoRepoTestFactory.params_for(:user)
+
+      assert user_params == %{name: "John Doe", admin: false}
     end
 
-    assert_raise RuntimeError, message, fn ->
-      EctoWithNoRepoFactory.insert_list(3, :user)
+    test "string_params_for/1 still works as expected" do
+      user_params = NoRepoTestFactory.string_params_for(:user)
+
+      assert user_params == %{"name" => "John Doe", "admin" => false}
     end
   end
 

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -4,17 +4,23 @@ defmodule ExMachina.EctoTest do
   alias ExMachina.TestFactory
   alias ExMachina.User
 
-  test "raises helpful error message if no repo is provided" do
+  test "insert raises helpful error message if no repo was provided" do
     message = """
-    expected :repo to be given as an option. Example:
+    insert/1 is not available unless you provide the :repo option. Example:
 
     use ExMachina.Ecto, repo: MyApp.Repo
     """
 
-    assert_raise ArgumentError, message, fn ->
-      defmodule EctoWithNoRepo do
-        use ExMachina.Ecto
+    defmodule EctoWithNoRepoFactory do
+      use ExMachina.Ecto
+
+      def user_factory do
+        %ExMachina.User{}
       end
+    end
+
+    assert_raise RuntimeError, message, fn ->
+      EctoWithNoRepoFactory.insert(:user)
     end
   end
 


### PR DESCRIPTION
We should be able to use Ecto without a repo. This is useful when using `ecto` without `ecto_sql`.

ExMachina currently raising an ArgumentError when using ExMachina.Ecto without a repo. This change now allows the repo to be nil and raises a RuntimeError when the insert/1 function is called instead.

New error message should still be helpful enough for people that simply forgot to add the :repo option.

```
insert/1 is not available unless you provide the :repo option. Example:

use ExMachina.Ecto, repo: MyApp.Repo
```

I believe this addresses the following issues:
https://github.com/thoughtbot/ex_machina/issues/369
https://github.com/thoughtbot/ex_machina/issues/355


