### PR TITLE
Update Reference to Prior Art

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule ExMachina.Mixfile do
       app: :ex_machina,
       version: @version,
       elixir: ">= 1.4.0",
-      description: "A factory library by the creators of FactoryGirl",
+      description: "A factory library by the creators of FactoryBot (née FactoryGirl)",
       source_url: @project_url,
       homepage_url: @project_url,
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
FactoryGirl hasn't been named as such for quite a while. I've preserved the name in the commit to ensure this library is still found when searching for something along the lines of "elixir factorygirl".