### PR TITLE
Fix elixir 1.11 warning by using extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,14 +23,10 @@ defmodule ExMachina.Mixfile do
 
   def application() do
     [
-      applications: app_list(Mix.env()),
+      extra_applications: [:logger],
       mod: {ExMachina, []}
     ]
   end
-
-  def app_list(:test), do: app_list() ++ [:ecto, :postgrex]
-  def app_list(_), do: app_list()
-  def app_list(), do: [:logger]
 
   defp deps() do
     [


### PR DESCRIPTION
## Motivation

I'm getting the following warning after upgrading to elixir 1.11. Related #398 #399.

```
warning: Ecto.Type.cast/2 defined in application :ecto is used by the current application but the current application does not directly depend on :ecto. To fix this, you must do one of:

  1. If :ecto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ecto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ecto, you may optionally skip this warning by adding [xref: [exclude: Ecto.Type]] to your "def project" in mix.exs

  lib/ex_machina/ecto_strategy.ex:62: ExMachina.EctoStrategy.cast_value/3
```

## Proposed Solution

By default, the list of applications to start is automatically inferred from the dependencies. Mix and other tools use the application list in order to start the dependencies before starting the application itself. If we use the `applications:` then no inference is done. In this case `ecto` was not been included as a dependency of the library.

A quick solution for this is to use the `extra_applications`, in this way we let the compiler infer from the dependencies list the applications that it needs to start.

Links:

- https://elixir-lang.org/blog/2017/01/05/elixir-v1-4-0-released/#application-inference
- https://hexdocs.pm/mix/Mix.Tasks.Compile.App.html
- https://stackoverflow.com/questions/44727642/elixir-mix-file-applications-vs-extra-applications-when-to-use-which