### PR TITLE
Introduce `build_lazy/2`

### DIFF
--- a/lib/ex_machina/instance_template.ex
+++ b/lib/ex_machina/instance_template.ex
@@ -1,0 +1,10 @@
+defmodule ExMachina.InstanceTemplate do
+  @moduledoc false
+
+  defstruct [:module, :name, :attrs]
+
+  @doc false
+  def evaluate(%{module: module, name: name, attrs: attrs}) do
+    apply(module, :build, [name, attrs])
+  end
+end

--- a/priv/test_repo/migrations/1_migrate_all.exs
+++ b/priv/test_repo/migrations/1_migrate_all.exs
@@ -3,23 +3,29 @@ defmodule ExMachina.TestRepo.Migrations.MigrateAll do
 
   def change do
     create table(:users) do
-      add :name, :string
-      add :admin, :boolean
-      add :net_worth, :decimal
+      add(:name, :string)
+      add(:admin, :boolean)
+      add(:net_worth, :decimal)
     end
 
+    create table(:publishers) do
+      add(:pub_number, :string)
+    end
+
+    create(unique_index(:publishers, [:pub_number]))
+
     create table(:articles) do
-      add :title, :string
-      add :author_id, :integer
-      add :editor_id, :integer
-      add :publisher_id, :integer
-      add :visits, :decimal
+      add(:title, :string)
+      add(:author_id, :integer)
+      add(:editor_id, :integer)
+      add(:publisher_id, :integer)
+      add(:visits, :decimal)
     end
 
     create table(:comments) do
-      add :article_id, :integer
-      add :author, :map
-      add :links, {:array, :map}, default: []
+      add(:article_id, :integer)
+      add(:author, :map)
+      add(:links, {:array, :map}, default: [])
     end
   end
 end

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -1,6 +1,8 @@
 defmodule ExMachina.EctoTest do
   use ExMachina.EctoCase
 
+  alias ExMachina.Article
+  alias ExMachina.Publisher
   alias ExMachina.TestFactory
   alias ExMachina.User
 
@@ -64,6 +66,23 @@ defmodule ExMachina.EctoTest do
 
     test "insert_list/3 handles the number 0" do
       assert [] = TestFactory.insert_list(0, :user)
+    end
+
+    test "build_lazy records get evaluated with insert/2 and insert_* functions" do
+      assert %Article{publisher: %Publisher{}} =
+               TestFactory.insert(:article, publisher: TestFactory.build_lazy(:publisher))
+
+      [%Article{publisher: publisher1}, %Article{publisher: publisher2}] =
+        TestFactory.insert_pair(:article, publisher: TestFactory.build_lazy(:publisher))
+
+      assert publisher1 != publisher2
+
+      [publisher1, publisher2, publisher3] =
+        TestFactory.insert_list(3, :article, publisher: TestFactory.build_lazy(:publisher))
+
+      assert publisher1.author != publisher2.author
+      assert publisher2.author != publisher3.author
+      assert publisher3.author != publisher1.author
     end
   end
 

--- a/test/ex_machina_test.exs
+++ b/test/ex_machina_test.exs
@@ -1,6 +1,10 @@
 defmodule ExMachinaTest do
   use ExUnit.Case
 
+  defmodule FooBar do
+    defstruct [:name]
+  end
+
   defmodule Factory do
     use ExMachina
 
@@ -24,10 +28,8 @@ defmodule ExMachinaTest do
       }
     end
 
-    def struct_factory do
-      %{
-        __struct__: Foo.Bar
-      }
+    def foo_bar_factory do
+      %FooBar{}
     end
 
     def comment_factory(attrs) do
@@ -94,7 +96,7 @@ defmodule ExMachinaTest do
 
     test "build/2 raises if passing invalid keys to a struct factory" do
       assert_raise KeyError, fn ->
-        Factory.build(:struct, doesnt_exist: true)
+        Factory.build(:foo_bar, doesnt_exist: true)
       end
     end
 

--- a/test/support/models/publisher.ex
+++ b/test/support/models/publisher.ex
@@ -1,6 +1,7 @@
 defmodule ExMachina.Publisher do
   use Ecto.Schema
 
-  schema "users" do
+  schema "publishers" do
+    field(:pub_number, :string)
   end
 end

--- a/test/support/test_factory.ex
+++ b/test/support/test_factory.ex
@@ -18,7 +18,9 @@ defmodule ExMachina.TestFactory do
   end
 
   def publisher_factory do
-    %ExMachina.Publisher{}
+    %ExMachina.Publisher{
+      pub_number: sequence("PUB_23")
+    }
   end
 
   def article_factory do


### PR DESCRIPTION
Closes https://github.com/thoughtbot/ex_machina/issues/402, https://github.com/thoughtbot/ex_machina/issues/385, and https://github.com/thoughtbot/ex_machina/issues/373

The problem
------------

Consider this scenario. People want a different email per account (especially if the email factory has a sequence), but they do this:

```elixir
build_pair(:account, email: build(:email))
```

The problem is that `build/2` is just function calling. So the above is equivalent to this:

```elixir
email = build(:email)
build_pair(:account, email: email)
```

In other words, we get one email factory for all of the accounts.

The problem is worse when using it with Ecto. We can image the following scenario:

```elixir
insert_pair(:account, user: build(:user))
```

If the user factory has a uniqueness constraint, `insert_pair/2` will raise an error because we'll try to insert a user with the same value (even if using a sequence).

Solution
--------

The solution is to delay evaluation of the factory. We do this by introducing a private struct `%ExMachina.InstanceTemplate{}` to hold the data necessary to build the instance of that factory.

Note that this struct is private and liable to change, so users of the library shouldn't depend on it.

The trick then lies in the `build/2` function. We make it a terminal function in that it will evaluate any lazy factories recursively. To do that, we update the `build/2` function to evaluate `ExMachina.InstanceTemplate` structs after building the `build/2` factory.

In an early implementation of this feature, I evaluated the lazy factories when we first got the attributes in `build/2` (i.e. `attrs |> evaluate_lazy_factories() |> Enum.into(%{})`). But then I opted for evaluating the lazy factories after the factory is created because that allows us to use `build_lazy/2` from within factory definitions, and not just when combined with `build/2` or `build_*` functions.