### PR TITLE
Preserve dates when using string_params_for

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,15 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+# By default, ExMachina will convert datetime values to a map with string
+# keys such as
+# %{ "calendar" => Calendar.ISO, "day" => 4, "hour" => 17, "microsecond" => {657863, 6}, "minute" => 25, "month" => 8, "second" => 42, "std_offset" => 0, "time_zone" => "Etc/UTC", "utc_offset" => 0, "year" => 2019, "zone_abbr" => "UTC" }
+# If you would like the date values to be preserved, you can set the following
+# config value. This may be made the default in the future but is a breaking change.
+#
+# config :ex_machina, preserve_dates: true
+#
+#
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+config :ex_machina, preserve_dates: true
+
 config :ex_machina, ExMachina.TestRepo,
   hostname: "localhost",
   database: "ex_machina_test",

--- a/lib/ex_machina/ecto.ex
+++ b/lib/ex_machina/ecto.ex
@@ -353,6 +353,14 @@ defmodule ExMachina.Ecto do
     Enum.map(values, &convert_atom_keys_to_strings/1)
   end
 
+  defp convert_atom_keys_to_strings(%NaiveDateTime{} = value) do
+    if Application.get_env(:ex_machina, :preserve_dates, false), do: value, else: Map.from_struct(value) |> convert_atom_keys_to_strings()
+  end
+
+  defp convert_atom_keys_to_strings(%DateTime{} = value) do
+    if Application.get_env(:ex_machina, :preserve_dates, false), do: value, else: Map.from_struct(value) |> convert_atom_keys_to_strings()
+  end
+
   defp convert_atom_keys_to_strings(%{__struct__: _} = record) when is_map(record) do
     Map.from_struct(record) |> convert_atom_keys_to_strings()
   end

--- a/priv/test_repo/migrations/1_migrate_all.exs
+++ b/priv/test_repo/migrations/1_migrate_all.exs
@@ -40,6 +40,7 @@ defmodule ExMachina.TestRepo.Migrations.MigrateAll do
       add(:editor_id, :integer)
       add(:publisher_id, :integer)
       add(:visits, :decimal)
+      add(:published_at, :utc_datetime)
     end
 
     create table(:comments) do

--- a/test/ex_machina/ecto_test.exs
+++ b/test/ex_machina/ecto_test.exs
@@ -261,6 +261,18 @@ defmodule ExMachina.EctoTest do
                %{"url" => "https://github.com", "rating" => 4}
              ]
     end
+
+    test "string_params_for/2 converts map with datetime as expected" do
+      published_at = DateTime.utc_now();
+      article_params = TestFactory.string_params_for(:article, published_at: published_at)
+      assert article_params["published_at"] == published_at
+    end
+
+    test "string_params_for/2 converts map with naive datetime as expected" do
+      published_at = ~N[2000-01-01 23:00:07]
+      article_params = TestFactory.string_params_for(:article, published_at: published_at)
+      assert article_params["published_at"] == published_at
+    end
   end
 
   describe "params_with_assocs/2" do

--- a/test/support/models/article.ex
+++ b/test/support/models/article.ex
@@ -4,6 +4,7 @@ defmodule ExMachina.Article do
   schema "articles" do
     field(:title, :string)
     field(:visits, :decimal)
+    field(:published_at, :utc_datetime)
 
     belongs_to(:author, ExMachina.User)
     belongs_to(:editor, ExMachina.User)


### PR DESCRIPTION
Resolves https://github.com/thoughtbot/ex_machina/issues/362

This PR introduces a configuration option to preserve dates when using the `string_params_for` function, making it a non breaking change for now.

Add the following
```
config :ex_machina, preserve_dates: true
```
to your config/test.exs file to enable this.